### PR TITLE
Add marketing SEO pages and demo CTA

### DIFF
--- a/apps/web/src/app/pricing/page.tsx
+++ b/apps/web/src/app/pricing/page.tsx
@@ -1,0 +1,640 @@
+import type { Metadata } from "next";
+import { DEMO_BOOKING_URL } from "@/lib/links";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Pricing — AI Voice Agent Plans",
+  description:
+    "QuickVoice pricing starts free. Choose from 6 plans — Free, PAYG, Starter ($49/mo), Growth ($99/mo), Scale ($399/mo), and Enterprise. No hidden fees.",
+  alternates: {
+    canonical: "https://quickvoice.co/pricing",
+  },
+  openGraph: {
+    title: "Pricing — AI Voice Agent Plans",
+    description:
+      "QuickVoice pricing starts free. Choose from 6 plans. No hidden fees.",
+    type: "website",
+    url: "https://quickvoice.co/pricing",
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Static plan data (mirrors data/plans.ts without importing icons)  */
+/* ------------------------------------------------------------------ */
+
+const PLANS = [
+  {
+    name: "Free",
+    price: "$0",
+    period: "",
+    agents: "1",
+    minutes: "15 mins/mo",
+    effectiveRate: "—",
+    overageRate: "—",
+    keyFeatures: [
+      "Browser playground only",
+      "Non-commercial use",
+      "15 test minutes per month",
+    ],
+    cta: "Get Started",
+    ctaHref: "/register",
+    popular: false,
+  },
+  {
+    name: "PAYG",
+    price: "$0",
+    period: "+ $0.25/min",
+    agents: "1",
+    minutes: "Pay as you go",
+    effectiveRate: "$0.25/min",
+    overageRate: "$0.25/min",
+    keyFeatures: [
+      "API + webhooks + telephony",
+      "Per-second billing",
+      "1 workspace",
+    ],
+    cta: "Get Started",
+    ctaHref: "/register",
+    popular: false,
+  },
+  {
+    name: "Starter",
+    price: "$49",
+    period: "/mo",
+    agents: "3",
+    minutes: "245 mins/mo",
+    effectiveRate: "$0.20/min",
+    overageRate: "$0.25/min",
+    keyFeatures: [
+      "Basic analytics",
+      "Email support",
+      "Telephony enabled",
+    ],
+    cta: "Subscribe",
+    ctaHref: "/register",
+    popular: false,
+  },
+  {
+    name: "Growth",
+    price: "$99",
+    period: "/mo",
+    agents: "5",
+    minutes: "600 mins/mo",
+    effectiveRate: "$0.165/min",
+    overageRate: "$0.22/min",
+    keyFeatures: [
+      "Call transcripts & redaction",
+      "SSO (add-on)",
+      "Telephony enabled",
+    ],
+    cta: "Subscribe",
+    ctaHref: "/register",
+    popular: false,
+  },
+  {
+    name: "Scale",
+    price: "$399",
+    period: "/mo",
+    agents: "10",
+    minutes: "2,660 mins/mo",
+    effectiveRate: "$0.15/min",
+    overageRate: "$0.20/min",
+    keyFeatures: [
+      "HIPAA-ready logging",
+      "Priority support",
+      "Reserved concurrency",
+    ],
+    cta: "Subscribe",
+    ctaHref: "/register",
+    popular: true,
+  },
+  {
+    name: "Enterprise",
+    price: "$1,500",
+    period: "/mo",
+    agents: "Custom",
+    minutes: "10,000+ mins/mo",
+    effectiveRate: "$0.15/min",
+    overageRate: "Custom",
+    keyFeatures: [
+      "Custom SLA & BAA",
+      "Dedicated support",
+      "Private networking & SSO/SCIM",
+    ],
+    cta: "Book a Demo",
+    ctaHref: DEMO_BOOKING_URL,
+    popular: false,
+  },
+] as const;
+
+/* ------------------------------------------------------------------ */
+/*  Feature matrix                                                     */
+/* ------------------------------------------------------------------ */
+
+const FEATURE_ROWS: { label: string; plans: boolean[] }[] = [
+  { label: "Browser playground",        plans: [true,  true,  true,  true,  true,  true] },
+  { label: "API & webhooks",            plans: [false, true,  true,  true,  true,  true] },
+  { label: "Telephony (inbound/outbound)", plans: [false, true, true, true, true, true] },
+  { label: "Call transcripts",          plans: [false, false, false, true,  true,  true] },
+  { label: "PII redaction",             plans: [false, false, false, true,  true,  true] },
+  { label: "Analytics dashboard",       plans: [false, false, true,  true,  true,  true] },
+  { label: "Email support",             plans: [false, false, true,  true,  true,  true] },
+  { label: "Priority support",          plans: [false, false, false, false, true,  true] },
+  { label: "HIPAA-ready logging",       plans: [false, false, false, false, true,  true] },
+  { label: "Reserved concurrency",      plans: [false, false, false, false, true,  true] },
+  { label: "SSO / SCIM",                plans: [false, false, false, false, false, true] },
+  { label: "Custom SLA",                plans: [false, false, false, false, false, true] },
+  { label: "BAA available",             plans: [false, false, false, false, false, true] },
+  { label: "Private networking",        plans: [false, false, false, false, false, true] },
+  { label: "Dedicated account manager", plans: [false, false, false, false, false, true] },
+];
+
+/* ------------------------------------------------------------------ */
+/*  FAQs                                                               */
+/* ------------------------------------------------------------------ */
+
+const FAQS = [
+  {
+    q: "Is there really a free plan?",
+    a: "Yes. The Free plan gives you 1 agent and 15 browser-only minutes every month at no cost. No credit card is required to sign up.",
+  },
+  {
+    q: "How does the PAYG plan work?",
+    a: "PAYG (Pay As You Go) has no monthly fee. You are billed per second at an effective rate of $0.25 per minute for every call your agent handles. Telephony, API, and webhooks are all enabled.",
+  },
+  {
+    q: "What happens if I exceed my included minutes?",
+    a: "If you go over the minutes included in your plan, additional usage is billed at the overage rate listed for your tier. For example, Starter overages are $0.25/min while Scale overages are $0.20/min.",
+  },
+  {
+    q: "Can I upgrade or downgrade at any time?",
+    a: "Absolutely. You can change plans at any point from your account dashboard. Upgrades take effect immediately, and downgrades apply at the start of your next billing cycle.",
+  },
+  {
+    q: "Do you offer annual billing discounts?",
+    a: "Yes. Annual plans receive a discount compared to month-to-month pricing. Contact our sales team for a custom annual quote.",
+  },
+  {
+    q: "Is QuickVoice HIPAA-compliant?",
+    a: "Our Scale and Enterprise plans include HIPAA-ready logging and we can sign a Business Associate Agreement (BAA) on the Enterprise tier. Contact us to discuss compliance requirements.",
+  },
+  {
+    q: "What payment methods do you accept?",
+    a: "We accept all major credit and debit cards (Visa, Mastercard, American Express) processed securely through Stripe. Enterprise customers can also pay by invoice.",
+  },
+  {
+    q: "How do I get started with Enterprise?",
+    a: "Book a demo with our team. We will work with you to tailor agents, minutes, concurrency, and SLAs to your exact needs.",
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  JSON-LD schemas                                                    */
+/* ------------------------------------------------------------------ */
+
+const pricingSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "QuickVoice",
+  applicationCategory: "BusinessApplication",
+  operatingSystem: "Web",
+  browserRequirements: "Requires JavaScript. Requires HTML5.",
+  url: "https://quickvoice.co/pricing",
+  offers: [
+    { "@type": "Offer", name: "Free",       price: "0",    priceCurrency: "USD", description: "1 agent, 15 mins/mo, browser only" },
+    { "@type": "Offer", name: "PAYG",       price: "0",    priceCurrency: "USD", description: "Pay $0.25/min, 1 agent, telephony enabled" },
+    { "@type": "Offer", name: "Starter",    price: "49",   priceCurrency: "USD", description: "3 agents, 245 mins/mo included" },
+    { "@type": "Offer", name: "Growth",     price: "99",   priceCurrency: "USD", description: "5 agents, 600 mins/mo included" },
+    { "@type": "Offer", name: "Scale",      price: "399",  priceCurrency: "USD", description: "10 agents, 2,660 mins/mo included" },
+    { "@type": "Offer", name: "Enterprise", price: "1500", priceCurrency: "USD", description: "Custom agents and minutes, dedicated support" },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQS.map((faq) => ({
+    "@type": "Question",
+    name: faq.q,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.a,
+    },
+  })),
+};
+
+/* ================================================================== */
+/*  Page component                                                     */
+/* ================================================================== */
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {/* ── JSON-LD ─────────────────────────────────────────────── */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(pricingSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+
+      {/* ── Hero ────────────────────────────────────────────────── */}
+      <section className="relative overflow-hidden pt-24 pb-16 text-center">
+        {/* Decorative blurs */}
+        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div className="absolute -top-[10%] left-1/2 h-[40%] w-[60%] -translate-x-1/2 rounded-full bg-primary/10 blur-3xl" />
+          <div className="absolute -bottom-[10%] -right-[10%] h-[40%] w-[40%] rounded-full bg-primary/5 blur-3xl" />
+        </div>
+
+        <div className="container mx-auto max-w-4xl px-4">
+          <p className="mb-4 inline-block rounded-full border border-primary/20 bg-primary/5 px-4 py-1 text-sm font-medium text-primary">
+            Pricing
+          </p>
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+            Simple, Transparent Pricing
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground">
+            Start free, upgrade when you are ready. Every plan includes
+            per-second billing, so you only pay for what you use.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Plan Cards (mobile) & Table (desktop) ───────────────── */}
+      <section className="container mx-auto max-w-7xl px-4 pb-20">
+        {/* ---- Mobile: stacked cards ---- */}
+        <div className="grid gap-6 sm:grid-cols-2 lg:hidden">
+          {PLANS.map((plan) => (
+            <div
+              key={plan.name}
+              className={`relative rounded-2xl border p-6 ${
+                plan.popular
+                  ? "border-primary ring-2 ring-primary/50 shadow-lg"
+                  : "border-border"
+              } bg-background`}
+            >
+              {plan.popular && (
+                <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-0.5 text-xs font-semibold text-primary-foreground">
+                  POPULAR
+                </span>
+              )}
+              <h3 className="text-lg font-semibold">{plan.name}</h3>
+              <div className="mt-2 flex items-baseline gap-1">
+                <span className="text-3xl font-bold">{plan.price}</span>
+                {plan.period && (
+                  <span className="text-muted-foreground">{plan.period}</span>
+                )}
+              </div>
+              <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+                <li>
+                  <span className="font-medium text-foreground">Agents:</span>{" "}
+                  {plan.agents}
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">Minutes:</span>{" "}
+                  {plan.minutes}
+                </li>
+                {plan.effectiveRate !== "—" && (
+                  <li>
+                    <span className="font-medium text-foreground">
+                      Effective rate:
+                    </span>{" "}
+                    {plan.effectiveRate}
+                  </li>
+                )}
+                {plan.overageRate !== "—" && (
+                  <li>
+                    <span className="font-medium text-foreground">
+                      Overage:
+                    </span>{" "}
+                    {plan.overageRate}
+                  </li>
+                )}
+              </ul>
+              <ul className="mt-4 space-y-1.5 text-sm">
+                {plan.keyFeatures.map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <svg
+                      className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                    {f}
+                  </li>
+                ))}
+              </ul>
+              <Link
+                href={plan.ctaHref}
+                className={`mt-6 block w-full rounded-lg px-4 py-2.5 text-center text-sm font-medium transition-colors ${
+                  plan.popular
+                    ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                    : "border border-border bg-muted hover:bg-muted/80 text-foreground"
+                }`}
+              >
+                {plan.cta}
+              </Link>
+            </div>
+          ))}
+        </div>
+
+        {/* ---- Desktop: comparison table ---- */}
+        <div className="hidden lg:block overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr>
+                <th className="border-b border-border p-4 text-left font-medium text-muted-foreground">
+                  &nbsp;
+                </th>
+                {PLANS.map((plan) => (
+                  <th
+                    key={plan.name}
+                    className={`relative border-b p-4 text-center font-semibold ${
+                      plan.popular
+                        ? "border-primary bg-primary/5"
+                        : "border-border"
+                    }`}
+                  >
+                    {plan.popular && (
+                      <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-0.5 text-xs font-semibold text-primary-foreground">
+                        POPULAR
+                      </span>
+                    )}
+                    {plan.name}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {/* Price */}
+              <tr>
+                <td className="p-4 font-medium">Price</td>
+                {PLANS.map((plan) => (
+                  <td
+                    key={plan.name}
+                    className={`p-4 text-center ${
+                      plan.popular ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    <span className="text-xl font-bold">{plan.price}</span>
+                    {plan.period && (
+                      <span className="text-muted-foreground">
+                        {plan.period}
+                      </span>
+                    )}
+                  </td>
+                ))}
+              </tr>
+              {/* Agents */}
+              <tr>
+                <td className="p-4 font-medium">Agents included</td>
+                {PLANS.map((plan) => (
+                  <td
+                    key={plan.name}
+                    className={`p-4 text-center ${
+                      plan.popular ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    {plan.agents}
+                  </td>
+                ))}
+              </tr>
+              {/* Minutes */}
+              <tr>
+                <td className="p-4 font-medium">Minutes per month</td>
+                {PLANS.map((plan) => (
+                  <td
+                    key={plan.name}
+                    className={`p-4 text-center ${
+                      plan.popular ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    {plan.minutes}
+                  </td>
+                ))}
+              </tr>
+              {/* Effective rate */}
+              <tr>
+                <td className="p-4 font-medium">Effective rate</td>
+                {PLANS.map((plan) => (
+                  <td
+                    key={plan.name}
+                    className={`p-4 text-center ${
+                      plan.popular ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    {plan.effectiveRate}
+                  </td>
+                ))}
+              </tr>
+              {/* Overage */}
+              <tr>
+                <td className="p-4 font-medium">Overage rate</td>
+                {PLANS.map((plan) => (
+                  <td
+                    key={plan.name}
+                    className={`p-4 text-center ${
+                      plan.popular ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    {plan.overageRate}
+                  </td>
+                ))}
+              </tr>
+              {/* Key features */}
+              <tr>
+                <td className="p-4 align-top font-medium">Key features</td>
+                {PLANS.map((plan) => (
+                  <td
+                    key={plan.name}
+                    className={`p-4 text-center align-top ${
+                      plan.popular ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    <ul className="inline-block space-y-1 text-left text-xs text-muted-foreground">
+                      {plan.keyFeatures.map((f) => (
+                        <li key={f} className="flex items-start gap-1.5">
+                          <svg
+                            className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M5 13l4 4L19 7"
+                            />
+                          </svg>
+                          {f}
+                        </li>
+                      ))}
+                    </ul>
+                  </td>
+                ))}
+              </tr>
+              {/* CTA row */}
+              <tr>
+                <td className="p-4">&nbsp;</td>
+                {PLANS.map((plan) => (
+                  <td
+                    key={plan.name}
+                    className={`p-4 text-center ${
+                      plan.popular ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    <Link
+                      href={plan.ctaHref}
+                      className={`inline-block rounded-lg px-5 py-2 text-sm font-medium transition-colors ${
+                        plan.popular
+                          ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                          : "border border-border bg-muted hover:bg-muted/80 text-foreground"
+                      }`}
+                    >
+                      {plan.cta}
+                    </Link>
+                  </td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* ── Feature Matrix ──────────────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-7xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Full Feature Comparison
+          </h2>
+          <p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
+            See exactly what is included in every plan so you can pick the right
+            fit for your team.
+          </p>
+
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[700px] border-collapse text-sm">
+              <thead>
+                <tr>
+                  <th className="border-b border-border p-3 text-left font-medium text-muted-foreground">
+                    Feature
+                  </th>
+                  {PLANS.map((plan) => (
+                    <th
+                      key={plan.name}
+                      className={`border-b p-3 text-center font-semibold ${
+                        plan.popular
+                          ? "border-primary bg-primary/5"
+                          : "border-border"
+                      }`}
+                    >
+                      {plan.name}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {FEATURE_ROWS.map((row) => (
+                  <tr key={row.label}>
+                    <td className="p-3 font-medium">{row.label}</td>
+                    {row.plans.map((available, i) => (
+                      <td
+                        key={PLANS[i].name}
+                        className={`p-3 text-center ${
+                          PLANS[i].popular ? "bg-primary/5" : ""
+                        }`}
+                      >
+                        {available ? (
+                          <svg
+                            className="mx-auto h-5 w-5 text-primary"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M5 13l4 4L19 7"
+                            />
+                          </svg>
+                        ) : (
+                          <span className="text-muted-foreground/40">—</span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ─────────────────────────────────────────────────── */}
+      <section className="py-20">
+        <div className="container mx-auto max-w-3xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Pricing FAQs
+          </h2>
+          <p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
+            Have questions? We have answers. If you need more help, feel free to{" "}
+            <Link
+              href="/company/contact"
+              className="text-primary underline underline-offset-4 hover:text-primary/80"
+            >
+              contact our team
+            </Link>
+            .
+          </p>
+
+          <dl className="divide-y divide-border">
+            {FAQS.map((faq) => (
+              <div key={faq.q} className="py-6">
+                <dt className="text-base font-semibold">{faq.q}</dt>
+                <dd className="mt-2 text-muted-foreground">{faq.a}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      {/* ── CTA ─────────────────────────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-2xl px-4 text-center">
+          <h2 className="text-3xl font-bold tracking-tight">
+            Ready to automate your calls?
+          </h2>
+          <p className="mx-auto mt-4 max-w-lg text-muted-foreground">
+            Join thousands of businesses using QuickVoice to handle inbound and
+            outbound calls with AI voice agents. Start free today.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/register"
+              className="inline-flex items-center justify-center rounded-lg bg-primary px-8 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            >
+              Get Started Free
+            </Link>
+            <Link
+              href={DEMO_BOOKING_URL}
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-8 py-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
+            >
+              Book a Demo
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/privacy-policy/page.tsx
+++ b/apps/web/src/app/privacy-policy/page.tsx
@@ -1,0 +1,517 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { DEMO_BOOKING_URL } from "@/lib/links";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "QuickVoice Privacy Policy — how we collect, use, and protect your data. Learn about your rights under GDPR, CCPA, and our commitment to data security.",
+  alternates: {
+    canonical: "https://quickvoice.co/privacy-policy",
+  },
+  openGraph: {
+    title: "Privacy Policy",
+    description:
+      "QuickVoice Privacy Policy — how we collect, use, and protect your data.",
+    type: "website",
+    url: "https://quickvoice.co/privacy-policy",
+    siteName: "QuickVoice",
+    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "QuickVoice Privacy Policy",
+    description:
+      "QuickVoice Privacy Policy — how we collect, use, and protect your data.",
+  },
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main className="bg-background text-foreground">
+      {/* Hero */}
+      <section className="border-b border-border/40 bg-muted/30 py-16 sm:py-20">
+        <div className="mx-auto max-w-4xl px-6">
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+            Privacy Policy
+          </h1>
+          <p className="mt-4 text-lg text-muted-foreground">
+            Last updated: February 2026
+          </p>
+        </div>
+      </section>
+
+      {/* Content */}
+      <section className="py-16 sm:py-20">
+        <div className="mx-auto max-w-4xl px-6">
+          <div className="prose prose-neutral dark:prose-invert max-w-none space-y-12">
+            {/* Introduction */}
+            <div>
+              <p className="text-lg leading-relaxed text-muted-foreground">
+                QuickVoice (&quot;we,&quot; &quot;our,&quot; or &quot;us&quot;)
+                is committed to protecting your privacy. This Privacy Policy
+                explains how we collect, use, disclose, and safeguard your
+                information when you visit our website at{" "}
+                <a
+                  href="https://quickvoice.co"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  quickvoice.co
+                </a>{" "}
+                and use our AI voice agent platform and related services
+                (collectively, the &quot;Services&quot;). Please read this
+                Privacy Policy carefully. By accessing or using our Services,
+                you acknowledge that you have read, understood, and agree to be
+                bound by this Privacy Policy.
+              </p>
+            </div>
+
+            {/* 1. Information We Collect */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                1. Information We Collect
+              </h2>
+
+              <h3 className="mt-6 text-xl font-medium">
+                1.1 Personal Information
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                When you register for an account, subscribe to our Services, or
+                contact us, we may collect personally identifiable information,
+                including but not limited to:
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>Full name</li>
+                <li>Email address</li>
+                <li>Phone number</li>
+                <li>Company name and job title</li>
+                <li>Billing and payment information (processed securely through third-party payment processors)</li>
+                <li>Mailing address</li>
+                <li>Account credentials</li>
+              </ul>
+
+              <h3 className="mt-6 text-xl font-medium">1.2 Usage Data</h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                We automatically collect certain information when you access or
+                use our Services, including:
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>IP address and approximate geolocation</li>
+                <li>Browser type and version</li>
+                <li>Operating system and device information</li>
+                <li>Pages visited, time spent on pages, and navigation paths</li>
+                <li>Referring and exit URLs</li>
+                <li>Date and time stamps of access</li>
+                <li>Feature usage patterns within the platform</li>
+                <li>Voice agent interaction logs and analytics (e.g., call duration, call outcomes, and aggregated performance metrics)</li>
+              </ul>
+
+              <h3 className="mt-6 text-xl font-medium">
+                1.3 Cookies and Tracking Technologies
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                We use cookies, web beacons, pixels, and similar tracking
+                technologies to enhance your experience, analyze trends, and
+                administer our Services. The types of cookies we use include:
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">Essential cookies:</strong>{" "}
+                  Required for core functionality such as authentication and security.
+                </li>
+                <li>
+                  <strong className="text-foreground">Analytics cookies:</strong>{" "}
+                  Help us understand how visitors interact with our website so we can improve the user experience.
+                </li>
+                <li>
+                  <strong className="text-foreground">Functional cookies:</strong>{" "}
+                  Remember your preferences, language settings, and other customizations.
+                </li>
+                <li>
+                  <strong className="text-foreground">Marketing cookies:</strong>{" "}
+                  Used to deliver relevant advertisements and track campaign performance.
+                </li>
+              </ul>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                You can control cookie preferences through your browser
+                settings. Disabling certain cookies may limit your ability to use
+                some features of our Services.
+              </p>
+
+              <h3 className="mt-6 text-xl font-medium">
+                1.4 Voice and Call Data
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                As an AI voice agent platform, we may process voice recordings,
+                transcriptions, and related metadata when you use our voice agent
+                features. This data is processed to deliver the Services and
+                improve voice agent performance. Call recordings and
+                transcriptions are stored securely and retained according to your
+                account settings and applicable law.
+              </p>
+            </div>
+
+            {/* 2. How We Use Your Information */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                2. How We Use Your Information
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                We use the information we collect for the following purposes:
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>To provide, operate, and maintain our Services</li>
+                <li>To create and manage your account</li>
+                <li>To process transactions and send billing-related communications</li>
+                <li>To personalize and improve your experience with our platform</li>
+                <li>To develop new features, products, and services</li>
+                <li>To analyze usage patterns and optimize platform performance</li>
+                <li>To train and improve our AI voice agent models using aggregated and de-identified data</li>
+                <li>To communicate with you, including sending service updates, security alerts, and support messages</li>
+                <li>To send marketing and promotional communications (with your consent, where required by law)</li>
+                <li>To detect, prevent, and address fraud, abuse, and security issues</li>
+                <li>To comply with legal obligations and enforce our terms</li>
+              </ul>
+            </div>
+
+            {/* 3. Data Sharing and Third Parties */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                3. Data Sharing and Third Parties
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                We do not sell your personal information. We may share your
+                information in the following circumstances:
+              </p>
+
+              <h3 className="mt-6 text-xl font-medium">
+                3.1 Service Providers
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                We engage trusted third-party service providers to perform
+                functions on our behalf, such as cloud hosting, payment
+                processing, analytics, email delivery, and customer support.
+                These providers have access to your information only to the
+                extent necessary to perform their services and are
+                contractually obligated to protect your data.
+              </p>
+
+              <h3 className="mt-6 text-xl font-medium">
+                3.2 Business Transfers
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                In the event of a merger, acquisition, reorganization,
+                bankruptcy, or sale of all or a portion of our assets, your
+                information may be transferred as part of that transaction. We
+                will notify you of any such change and any choices you may have
+                regarding your information.
+              </p>
+
+              <h3 className="mt-6 text-xl font-medium">
+                3.3 Legal Requirements
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                We may disclose your information if required to do so by law or
+                in the good-faith belief that such action is necessary to comply
+                with a legal obligation, protect and defend our rights or
+                property, prevent fraud, or protect the personal safety of users
+                or the public.
+              </p>
+
+              <h3 className="mt-6 text-xl font-medium">
+                3.4 With Your Consent
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                We may share your information with third parties when you
+                have given us explicit consent to do so.
+              </p>
+
+              <h3 className="mt-6 text-xl font-medium">
+                3.5 Aggregated or De-Identified Data
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                We may share aggregated, anonymized, or de-identified data that
+                cannot reasonably be used to identify you for research,
+                analytics, benchmarking, or marketing purposes.
+              </p>
+            </div>
+
+            {/* 4. Data Retention */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                4. Data Retention
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                We retain your personal information for as long as your account
+                is active or as needed to provide you with our Services. We may
+                also retain and use your information as necessary to:
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>Comply with our legal obligations</li>
+                <li>Resolve disputes and enforce our agreements</li>
+                <li>Maintain security and prevent fraud</li>
+                <li>Fulfill legitimate business purposes, such as analytics and reporting</li>
+              </ul>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                When your data is no longer required for these purposes, we will
+                securely delete or anonymize it. Voice recordings and call
+                transcriptions are retained based on your account configuration
+                and are automatically purged after the retention period you set,
+                unless a longer retention is required by law.
+              </p>
+            </div>
+
+            {/* 5. Your Rights */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                5. Your Rights
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                Depending on your jurisdiction, you may have the following rights
+                regarding your personal data:
+              </p>
+
+              <h3 className="mt-6 text-xl font-medium">
+                5.1 Rights Under the General Data Protection Regulation (GDPR)
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                If you are located in the European Economic Area (EEA), the
+                United Kingdom, or Switzerland, you have the right to:
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">Access</strong> — Request a copy of the personal data we hold about you.
+                </li>
+                <li>
+                  <strong className="text-foreground">Rectification</strong> — Request correction of inaccurate or incomplete data.
+                </li>
+                <li>
+                  <strong className="text-foreground">Erasure</strong> — Request deletion of your personal data (&quot;right to be forgotten&quot;).
+                </li>
+                <li>
+                  <strong className="text-foreground">Restriction</strong> — Request that we limit the processing of your data.
+                </li>
+                <li>
+                  <strong className="text-foreground">Portability</strong> — Receive your data in a structured, commonly used, machine-readable format.
+                </li>
+                <li>
+                  <strong className="text-foreground">Object</strong> — Object to the processing of your data for certain purposes, including direct marketing.
+                </li>
+                <li>
+                  <strong className="text-foreground">Withdraw Consent</strong> — Where processing is based on consent, withdraw that consent at any time.
+                </li>
+              </ul>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                You also have the right to lodge a complaint with your local data
+                protection authority.
+              </p>
+
+              <h3 className="mt-6 text-xl font-medium">
+                5.2 Rights Under the California Consumer Privacy Act (CCPA)
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                If you are a California resident, you have the right to:
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">Know</strong> — Request disclosure of the categories and specific pieces of personal information we have collected about you.
+                </li>
+                <li>
+                  <strong className="text-foreground">Delete</strong> — Request deletion of the personal information we have collected from you, subject to certain exceptions.
+                </li>
+                <li>
+                  <strong className="text-foreground">Opt-Out of Sale</strong> — We do not sell personal information. If this changes, you will have the right to opt out.
+                </li>
+                <li>
+                  <strong className="text-foreground">Non-Discrimination</strong> — You will not be discriminated against for exercising your privacy rights.
+                </li>
+              </ul>
+
+              <h3 className="mt-6 text-xl font-medium">
+                5.3 Exercising Your Rights
+              </h3>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                To exercise any of the above rights, please contact us at{" "}
+                <a
+                  href="mailto:support@quickvoice.co"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  support@quickvoice.co
+                </a>
+                . We will respond to your request within the timeframe required
+                by applicable law (typically 30 days for GDPR and 45 days for
+                CCPA). We may need to verify your identity before processing
+                your request.
+              </p>
+            </div>
+
+            {/* 6. Security Measures */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                6. Security Measures
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                We implement industry-standard technical and organizational
+                security measures to protect your personal information against
+                unauthorized access, alteration, disclosure, or destruction.
+                These measures include:
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>Encryption of data in transit (TLS/SSL) and at rest (AES-256)</li>
+                <li>Regular security assessments and penetration testing</li>
+                <li>Access controls and role-based permissions for internal systems</li>
+                <li>Secure software development practices</li>
+                <li>Employee security awareness training</li>
+                <li>Incident response and breach notification procedures</li>
+              </ul>
+              <p className="mt-3 leading-relaxed text-muted-foreground">
+                While we strive to protect your personal information, no method
+                of transmission over the Internet or electronic storage is
+                completely secure. We cannot guarantee absolute security, but we
+                are committed to continually improving our safeguards.
+              </p>
+            </div>
+
+            {/* 7. International Data Transfers */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                7. International Data Transfers
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                Your information may be transferred to, stored, and processed in
+                countries other than your country of residence, including the
+                United States and Canada. These countries may have data
+                protection laws that differ from those in your jurisdiction. When
+                we transfer data internationally, we implement appropriate
+                safeguards, such as Standard Contractual Clauses (SCCs) approved
+                by the European Commission, to ensure your data is protected in
+                accordance with this Privacy Policy and applicable law.
+              </p>
+            </div>
+
+            {/* 8. Children's Privacy */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                8. Children&apos;s Privacy
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                Our Services are not directed to individuals under the age of 16.
+                We do not knowingly collect personal information from children
+                under 16. If we become aware that we have inadvertently collected
+                personal data from a child under 16, we will take steps to
+                delete that information as promptly as possible. If you believe
+                that a child under 16 has provided us with personal information,
+                please contact us at{" "}
+                <a
+                  href="mailto:support@quickvoice.co"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  support@quickvoice.co
+                </a>
+                .
+              </p>
+            </div>
+
+            {/* 9. Third-Party Links */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                9. Third-Party Links
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                Our Services may contain links to third-party websites,
+                applications, or services that are not operated by us. We are not
+                responsible for the privacy practices of these third parties. We
+                encourage you to review the privacy policies of any third-party
+                services before providing them with your personal information.
+              </p>
+            </div>
+
+            {/* 10. Changes to This Privacy Policy */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                10. Changes to This Privacy Policy
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                We may update this Privacy Policy from time to time to reflect
+                changes in our practices, technology, legal requirements, or
+                other factors. When we make material changes, we will notify you
+                by updating the &quot;Last updated&quot; date at the top of this
+                page and, where required by law, by sending you an email
+                notification or displaying a prominent notice on our website. We
+                encourage you to review this Privacy Policy periodically to stay
+                informed about how we protect your data.
+              </p>
+            </div>
+
+            {/* 11. Contact Us */}
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                11. Contact Us
+              </h2>
+              <p className="mt-4 leading-relaxed text-muted-foreground">
+                If you have any questions, concerns, or requests regarding this
+                Privacy Policy or our data practices, please contact us:
+              </p>
+              <div className="mt-6 rounded-xl border border-border bg-muted/30 p-6 sm:p-8">
+                <p className="font-semibold text-foreground">QuickVoice</p>
+                <p className="mt-1 text-muted-foreground">
+                  Email:{" "}
+                  <a
+                    href="mailto:support@quickvoice.co"
+                    className="text-primary underline underline-offset-4 hover:text-primary/80"
+                  >
+                    support@quickvoice.co
+                  </a>
+                </p>
+                <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">
+                      United States
+                    </p>
+                    <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                      104 West 40th Street, Suite 1800
+                      <br />
+                      New York, NY 10018
+                      <br />
+                      United States
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-foreground">
+                      Canada
+                    </p>
+                    <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                      4000 Innovation Drive, 3rd Floor
+                      <br />
+                      Ottawa, Ontario K2K 3K1
+                      <br />
+                      Canada
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-border bg-muted/30 py-12">
+        <div className="mx-auto max-w-4xl px-6 text-center">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            Have privacy or security questions before you deploy?
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
+            Book time with a QuickVoice specialist to review data handling, voice records,
+            and compliance requirements for your use case.
+          </p>
+          <Link
+            href={DEMO_BOOKING_URL}
+            className="mt-6 inline-flex items-center justify-center rounded-lg bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+          >
+            Book a Demo
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -119,6 +119,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
 
+    // Solutions
+    {
+      url: `${baseUrl}/solutions`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/solutions/ai-receptionist`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/solutions/ai-answering-service`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+
     // Compliance
     {
       url: `${baseUrl}/compliance/hipaa`,

--- a/apps/web/src/app/solutions/ai-answering-service/page.tsx
+++ b/apps/web/src/app/solutions/ai-answering-service/page.tsx
@@ -1,0 +1,541 @@
+import type { Metadata } from "next";
+import { DEMO_BOOKING_URL } from "@/lib/links";
+import Link from "next/link";
+import {
+  Phone,
+  Clock,
+  DollarSign,
+  Bot,
+  Globe,
+  ShieldCheck,
+  Zap,
+  BarChart3,
+  Building2,
+  Stethoscope,
+  Scale,
+  Home,
+  Briefcase,
+  ChevronRight,
+  CheckCircle2,
+  XCircle,
+  ArrowRight,
+} from "lucide-react";
+
+/* ================================================================== */
+/*  Metadata                                                           */
+/* ================================================================== */
+
+export const metadata: Metadata = {
+  title: "AI Answering Service — Never Miss a Call",
+  description:
+    "QuickVoice AI answering service picks up every call 24/7 at $0.20/min. Replace hold music with instant, human-like responses. Start free today.",
+  keywords:
+    "ai answering service, AI phone answering, virtual receptionist AI, automated answering service, AI call answering, 24/7 answering service",
+  alternates: {
+    canonical: "https://quickvoice.co/solutions/ai-answering-service",
+  },
+  openGraph: {
+    title: "AI Answering Service — Never Miss a Call",
+    description:
+      "QuickVoice AI answering service picks up every call 24/7 at $0.20/min. Replace hold music with instant, human-like responses.",
+    type: "website",
+    url: "https://quickvoice.co/solutions/ai-answering-service",
+    siteName: "QuickVoice",
+    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI Answering Service — Never Miss a Call",
+    description:
+      "QuickVoice AI answering service picks up every call 24/7 at $0.20/min. Replace hold music with instant, human-like responses.",
+    images: ["/og-image.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+/* ================================================================== */
+/*  Static data                                                        */
+/* ================================================================== */
+
+const FEATURES = [
+  {
+    icon: Clock,
+    title: "24/7 Availability",
+    description:
+      "Your AI answering service never sleeps. Every call is picked up instantly — nights, weekends, and holidays included.",
+  },
+  {
+    icon: Globe,
+    title: "100+ Languages",
+    description:
+      "Serve callers in their preferred language with real-time multilingual support. No additional staff required.",
+  },
+  {
+    icon: Zap,
+    title: "Instant Call Handling",
+    description:
+      "Zero hold times. Callers get immediate, context-aware responses powered by natural language processing.",
+  },
+  {
+    icon: Bot,
+    title: "Human-Like Conversations",
+    description:
+      "Advanced AI voice models deliver natural, empathetic dialogue that callers trust and prefer over robotic IVR menus.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Enterprise Security",
+    description:
+      "SOC 2 Type II certified, HIPAA-ready logging, end-to-end encryption, and PII redaction built in.",
+  },
+  {
+    icon: BarChart3,
+    title: "Real-Time Analytics",
+    description:
+      "Track call volume, resolution rates, caller sentiment, and peak hours from a single dashboard.",
+  },
+];
+
+const INDUSTRIES = [
+  {
+    icon: Building2,
+    title: "Small Business",
+    description:
+      "Never lose a lead after hours. Capture caller info, answer FAQs, and route urgent calls to your mobile.",
+    href: "/industries",
+  },
+  {
+    icon: Stethoscope,
+    title: "Healthcare",
+    description:
+      "HIPAA-compliant appointment scheduling, prescription refill requests, and patient triage — 24/7.",
+    href: "/industries/healthcare",
+  },
+  {
+    icon: Scale,
+    title: "Legal",
+    description:
+      "Screen potential clients, schedule consultations, and capture case details without missing billable hours.",
+    href: "/industries",
+  },
+  {
+    icon: Home,
+    title: "Real Estate",
+    description:
+      "Qualify leads, schedule showings, and provide property details to every caller — even at midnight.",
+    href: "/industries/real-estate",
+  },
+  {
+    icon: Briefcase,
+    title: "Professional Services",
+    description:
+      "Route calls intelligently, manage appointment bookings, and deliver polished first impressions at scale.",
+    href: "/industries",
+  },
+  {
+    icon: DollarSign,
+    title: "Financial Services",
+    description:
+      "Handle account inquiries, route to the right advisor, and maintain full compliance with regulatory requirements.",
+    href: "/industries/financial-services",
+  },
+];
+
+const COMPARISON_ROWS = [
+  { feature: "Availability", ai: "24/7/365", traditional: "Business hours (or premium for after-hours)" },
+  { feature: "Cost per minute", ai: "$0.20/min", traditional: "$1.00 - $3.00/min" },
+  { feature: "Hold time", ai: "0 seconds", traditional: "30 sec - 5+ minutes" },
+  { feature: "Languages supported", ai: "100+", traditional: "1 - 3 (extra cost)" },
+  { feature: "Scalability", ai: "Unlimited concurrent calls", traditional: "Limited by staff count" },
+  { feature: "Setup time", ai: "Under 5 minutes", traditional: "Days to weeks" },
+  { feature: "Call analytics", ai: "Real-time dashboard", traditional: "Monthly reports (if any)" },
+  { feature: "Consistency", ai: "Every call, every time", traditional: "Varies by operator" },
+];
+
+const FAQS = [
+  {
+    q: "What is an AI answering service?",
+    a: "An AI answering service uses advanced voice AI to answer phone calls on behalf of your business. It understands natural language, responds in a human-like voice, captures caller information, schedules appointments, answers FAQs, and routes urgent calls — all without a live operator.",
+  },
+  {
+    q: "How does QuickVoice compare to a traditional answering service?",
+    a: "QuickVoice answers every call instantly with zero hold time, operates 24/7/365, supports 100+ languages, and costs as little as $0.20 per minute. Traditional services typically charge $1-3 per minute, are limited by staff availability, and may put callers on hold during peak periods.",
+  },
+  {
+    q: "Can the AI answering service transfer calls to a live person?",
+    a: "Yes. You can configure rules to transfer calls to a live agent based on caller intent, keywords, VIP caller lists, or time of day. The AI provides a warm handoff with full context so the human agent is up to speed immediately.",
+  },
+  {
+    q: "Is QuickVoice HIPAA compliant for healthcare use?",
+    a: "Yes. Our Scale and Enterprise plans include HIPAA-ready logging, automatic PHI redaction, and we can sign a Business Associate Agreement (BAA). This makes QuickVoice suitable for medical offices, dental clinics, and other healthcare organizations.",
+  },
+  {
+    q: "How long does it take to set up?",
+    a: "Most businesses are live in under 5 minutes. You create an AI agent in the QuickVoice dashboard, configure your greeting and call-handling rules, and forward your business phone number. No coding or hardware is required.",
+  },
+  {
+    q: "What happens if the AI cannot handle a caller's request?",
+    a: "The AI is designed to gracefully escalate. It can transfer the call to a live person, take a detailed message with a callback number, or send an email notification to your team. You control the escalation rules from your dashboard.",
+  },
+];
+
+/* ================================================================== */
+/*  JSON-LD structured data                                            */
+/* ================================================================== */
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQS.map((faq) => ({
+    "@type": "Question",
+    name: faq.q,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.a,
+    },
+  })),
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://quickvoice.co",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Solutions",
+      item: "https://quickvoice.co/solutions",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "AI Answering Service",
+      item: "https://quickvoice.co/solutions/ai-answering-service",
+    },
+  ],
+};
+
+/* ================================================================== */
+/*  Page component                                                     */
+/* ================================================================== */
+
+export default function AIAnsweringServicePage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      {/* ── JSON-LD ─────────────────────────────────────────────── */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+
+      {/* ── Hero ────────────────────────────────────────────────── */}
+      <section className="relative overflow-hidden pt-24 pb-16 text-center">
+        {/* Decorative blurs */}
+        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div className="absolute -top-[10%] left-1/2 h-[40%] w-[60%] -translate-x-1/2 rounded-full bg-primary/10 blur-3xl" />
+          <div className="absolute -bottom-[10%] -right-[10%] h-[40%] w-[40%] rounded-full bg-primary/5 blur-3xl" />
+        </div>
+
+        <div className="container mx-auto max-w-4xl px-4">
+          <p className="mb-4 inline-block rounded-full border border-primary/20 bg-primary/5 px-4 py-1 text-sm font-medium text-primary">
+            AI Answering Service
+          </p>
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+            Never Miss a Call Again
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground">
+            QuickVoice&apos;s AI answering service picks up every call instantly,
+            24/7, in over 100 languages — at a fraction of the cost of a
+            traditional answering service. No hold music. No missed leads.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/register"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-8 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            >
+              Start Free Trial
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href={DEMO_BOOKING_URL}
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-8 py-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
+            >
+              Talk to Sales
+            </Link>
+          </div>
+          <p className="mt-4 text-xs text-muted-foreground">
+            No credit card required. Live in under 5 minutes.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Why AI vs Traditional ────────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-5xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Why Choose AI Over a Traditional Answering Service?
+          </h2>
+          <p className="mx-auto mb-12 max-w-2xl text-center text-muted-foreground">
+            Traditional answering services are expensive, limited by
+            staff availability, and inconsistent. AI changes the equation.
+          </p>
+
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[600px] border-collapse text-sm">
+              <thead>
+                <tr>
+                  <th className="border-b border-border p-4 text-left font-medium text-muted-foreground">
+                    Feature
+                  </th>
+                  <th className="border-b border-primary bg-primary/5 p-4 text-center font-semibold">
+                    <span className="flex items-center justify-center gap-2">
+                      <Bot className="h-4 w-4 text-primary" />
+                      QuickVoice AI
+                    </span>
+                  </th>
+                  <th className="border-b border-border p-4 text-center font-semibold">
+                    Traditional Service
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {COMPARISON_ROWS.map((row) => (
+                  <tr key={row.feature}>
+                    <td className="p-4 font-medium">{row.feature}</td>
+                    <td className="bg-primary/5 p-4 text-center">
+                      <span className="inline-flex items-center gap-1.5 text-primary">
+                        <CheckCircle2 className="h-4 w-4 shrink-0" />
+                        {row.ai}
+                      </span>
+                    </td>
+                    <td className="p-4 text-center text-muted-foreground">
+                      {row.traditional}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Key Features ─────────────────────────────────────────── */}
+      <section className="py-20">
+        <div className="container mx-auto max-w-6xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Everything You Need in an AI Answering Service
+          </h2>
+          <p className="mx-auto mb-12 max-w-2xl text-center text-muted-foreground">
+            QuickVoice goes far beyond basic call answering. Here is what you get
+            out of the box.
+          </p>
+
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map((feature) => (
+              <div
+                key={feature.title}
+                className="rounded-2xl border border-border bg-background p-6 transition-shadow hover:shadow-lg"
+              >
+                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+                  <feature.icon className="h-6 w-6 text-primary" />
+                </div>
+                <h3 className="mb-2 text-lg font-semibold">{feature.title}</h3>
+                <p className="text-sm text-muted-foreground">
+                  {feature.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Industry Applications ─────────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-6xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            AI Answering for Every Industry
+          </h2>
+          <p className="mx-auto mb-12 max-w-2xl text-center text-muted-foreground">
+            From solo practitioners to enterprise teams, QuickVoice adapts to the
+            way your industry handles calls.
+          </p>
+
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {INDUSTRIES.map((industry) => (
+              <Link
+                key={industry.title}
+                href={industry.href}
+                className="group rounded-2xl border border-border bg-background p-6 transition-all hover:border-primary/40 hover:shadow-lg"
+              >
+                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+                  <industry.icon className="h-6 w-6 text-primary" />
+                </div>
+                <h3 className="mb-2 flex items-center gap-2 text-lg font-semibold">
+                  {industry.title}
+                  <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-1" />
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  {industry.description}
+                </p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Pricing Comparison ────────────────────────────────────── */}
+      <section className="py-20">
+        <div className="container mx-auto max-w-4xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Save Up to 90% vs. Traditional Answering Services
+          </h2>
+          <p className="mx-auto mb-12 max-w-2xl text-center text-muted-foreground">
+            Human answering services charge $1 - $3 per minute and still put your
+            callers on hold. QuickVoice answers instantly at $0.20/min.
+          </p>
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            {/* AI Card */}
+            <div className="relative rounded-2xl border-2 border-primary bg-primary/5 p-8">
+              <span className="absolute -top-3 left-6 rounded-full bg-primary px-3 py-0.5 text-xs font-semibold text-primary-foreground">
+                RECOMMENDED
+              </span>
+              <div className="mb-4 flex items-center gap-3">
+                <Bot className="h-8 w-8 text-primary" />
+                <h3 className="text-xl font-bold">QuickVoice AI</h3>
+              </div>
+              <div className="mb-6 flex items-baseline gap-1">
+                <span className="text-4xl font-bold">$0.20</span>
+                <span className="text-muted-foreground">/min</span>
+              </div>
+              <ul className="space-y-3 text-sm">
+                {[
+                  "24/7/365 availability",
+                  "Zero hold time",
+                  "100+ languages included",
+                  "Unlimited concurrent calls",
+                  "Real-time analytics dashboard",
+                  "No contracts or setup fees",
+                  "Live in under 5 minutes",
+                ].map((item) => (
+                  <li key={item} className="flex items-start gap-2">
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <Link
+                href="/pricing"
+                className="mt-8 block w-full rounded-lg bg-primary px-4 py-3 text-center text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                View All Plans
+              </Link>
+            </div>
+
+            {/* Traditional Card */}
+            <div className="rounded-2xl border border-border bg-background p-8">
+              <div className="mb-4 flex items-center gap-3">
+                <Phone className="h-8 w-8 text-muted-foreground" />
+                <h3 className="text-xl font-bold">Traditional Service</h3>
+              </div>
+              <div className="mb-6 flex items-baseline gap-1">
+                <span className="text-4xl font-bold">$1 - $3</span>
+                <span className="text-muted-foreground">/min</span>
+              </div>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {[
+                  "Business hours (after-hours costs extra)",
+                  "30-second to 5-minute hold times",
+                  "1 - 3 languages (extra fees)",
+                  "Limited by operator count",
+                  "Monthly PDF reports",
+                  "12-month contracts typical",
+                  "1 - 2 week onboarding",
+                ].map((item) => (
+                  <li key={item} className="flex items-start gap-2">
+                    <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground/50" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8 block w-full rounded-lg border border-border bg-muted px-4 py-3 text-center text-sm font-medium text-muted-foreground">
+                Industry Average
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ─────────────────────────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-3xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Frequently Asked Questions
+          </h2>
+          <p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
+            Everything you need to know about our AI answering service. Can&apos;t
+            find what you&apos;re looking for?{" "}
+            <Link
+              href="/company/contact"
+              className="text-primary underline underline-offset-4 hover:text-primary/80"
+            >
+              Contact our team
+            </Link>
+            .
+          </p>
+
+          <dl className="divide-y divide-border">
+            {FAQS.map((faq) => (
+              <div key={faq.q} className="py-6">
+                <dt className="text-base font-semibold">{faq.q}</dt>
+                <dd className="mt-2 text-muted-foreground">{faq.a}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      {/* ── Bottom CTA ───────────────────────────────────────────── */}
+      <section className="py-20">
+        <div className="container mx-auto max-w-2xl px-4 text-center">
+          <h2 className="text-3xl font-bold tracking-tight">
+            Ready to Let AI Answer Your Calls?
+          </h2>
+          <p className="mx-auto mt-4 max-w-lg text-muted-foreground">
+            Join thousands of businesses that trust QuickVoice to deliver
+            instant, professional call handling around the clock. Start for free
+            — no credit card required.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/register"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-8 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            >
+              Get Started Free
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href={DEMO_BOOKING_URL}
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-8 py-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
+            >
+              Book a Demo
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/solutions/ai-receptionist/page.tsx
+++ b/apps/web/src/app/solutions/ai-receptionist/page.tsx
@@ -1,0 +1,597 @@
+import type { Metadata } from "next";
+import { DEMO_BOOKING_URL } from "@/lib/links";
+import Link from "next/link";
+import {
+  Phone,
+  CalendarCheck,
+  ArrowRightLeft,
+  Globe,
+  ShieldCheck,
+  RefreshCw,
+  Settings,
+  Plug,
+  Rocket,
+  Clock,
+  Building2,
+  Stethoscope,
+  Scale,
+  SmilePlus,
+  CheckCircle2,
+  XCircle,
+  ChevronRight,
+} from "lucide-react";
+
+/* ------------------------------------------------------------------ */
+/*  Metadata                                                           */
+/* ------------------------------------------------------------------ */
+
+export const metadata: Metadata = {
+  title: "AI Receptionist — 24/7 Automated Call Answering",
+  description:
+    "Deploy an AI receptionist that answers calls 24/7, books appointments, and routes callers. HIPAA compliant. 100+ languages. Try free.",
+  alternates: {
+    canonical: "https://quickvoice.co/solutions/ai-receptionist",
+  },
+  openGraph: {
+    title: "AI Receptionist — 24/7 Automated Call Answering",
+    description:
+      "Deploy an AI receptionist that answers calls 24/7, books appointments, and routes callers. HIPAA compliant. 100+ languages. Try free.",
+    url: "https://quickvoice.co/solutions/ai-receptionist",
+    siteName: "QuickVoice",
+    type: "website",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "QuickVoice AI Receptionist — 24/7 Automated Call Answering",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI Receptionist — 24/7 Automated Call Answering",
+    description:
+      "Deploy an AI receptionist that answers calls 24/7, books appointments, and routes callers. HIPAA compliant. 100+ languages. Try free.",
+    images: ["/og-image.png"],
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Static data                                                        */
+/* ------------------------------------------------------------------ */
+
+const STEPS = [
+  {
+    step: "1",
+    title: "Configure",
+    description:
+      "Set your greeting, business hours, call routing rules, and FAQ answers in a no-code dashboard. Upload your knowledge base so the AI speaks your brand voice.",
+    icon: Settings,
+  },
+  {
+    step: "2",
+    title: "Connect",
+    description:
+      "Forward your existing business number or provision a new one. Integrate with your calendar, CRM, and helpdesk in a few clicks.",
+    icon: Plug,
+  },
+  {
+    step: "3",
+    title: "Go Live",
+    description:
+      "Your AI receptionist starts answering calls instantly. Monitor live dashboards, review transcripts, and fine-tune as needed.",
+    icon: Rocket,
+  },
+];
+
+const FEATURES = [
+  {
+    title: "24/7 Call Answering",
+    description:
+      "Never miss a call again. Your AI receptionist picks up on the first ring, day or night, weekends and holidays included.",
+    icon: Clock,
+  },
+  {
+    title: "Appointment Scheduling",
+    description:
+      "Callers can book, reschedule, or cancel appointments in real time. The AI syncs with Google Calendar, Calendly, and more.",
+    icon: CalendarCheck,
+  },
+  {
+    title: "Intelligent Call Routing",
+    description:
+      "Route callers to the right department or team member based on intent, priority, or custom rules you define.",
+    icon: ArrowRightLeft,
+  },
+  {
+    title: "Multi-Language Support",
+    description:
+      "Serve a global audience with support for 100+ languages. The AI detects the caller's language automatically.",
+    icon: Globe,
+  },
+  {
+    title: "HIPAA Compliant",
+    description:
+      "Built for regulated industries. Encrypted data, PHI redaction, audit logs, and BAA available on qualifying plans.",
+    icon: ShieldCheck,
+  },
+  {
+    title: "CRM Sync",
+    description:
+      "Log every call, capture lead details, and push data to Salesforce, HubSpot, or your custom CRM via API.",
+    icon: RefreshCw,
+  },
+];
+
+const USE_CASES = [
+  {
+    industry: "Healthcare",
+    description:
+      "Handle patient intake calls, schedule appointments, send reminders, and route urgent calls to on-call staff — all while staying HIPAA compliant.",
+    icon: Stethoscope,
+  },
+  {
+    industry: "Real Estate",
+    description:
+      "Capture buyer and seller leads 24/7, schedule property showings, and qualify prospects before they reach your agents.",
+    icon: Building2,
+  },
+  {
+    industry: "Legal",
+    description:
+      "Screen potential clients, collect case details, schedule consultations, and ensure no prospective client call goes unanswered.",
+    icon: Scale,
+  },
+  {
+    industry: "Dental",
+    description:
+      "Book hygiene appointments, handle insurance verification questions, and send automated appointment confirmations and reminders.",
+    icon: SmilePlus,
+  },
+];
+
+const ROI_STATS = [
+  {
+    stat: "62%",
+    label: "of calls go unanswered after hours",
+    description: "Every missed call is a missed opportunity. An AI receptionist ensures zero calls go to voicemail.",
+  },
+  {
+    stat: "80%",
+    label: "of routine calls handled by AI",
+    description: "Free your team to focus on high-value work while the AI handles FAQs, scheduling, and routing.",
+  },
+  {
+    stat: "$3K+",
+    label: "average monthly savings",
+    description: "Eliminate the cost of full-time receptionists, overtime pay, and outsourced answering services.",
+  },
+];
+
+const COMPARISON_ROWS = [
+  {
+    feature: "Monthly Cost",
+    ai: "From $49/mo",
+    traditional: "$800 - $2,500/mo",
+  },
+  {
+    feature: "Availability",
+    ai: "24/7/365",
+    traditional: "Business hours only",
+  },
+  {
+    feature: "Languages",
+    ai: "100+",
+    traditional: "1 - 2",
+  },
+  {
+    feature: "Scalability",
+    ai: "Unlimited concurrent calls",
+    traditional: "Limited by headcount",
+  },
+  {
+    feature: "Setup Time",
+    ai: "Minutes",
+    traditional: "Days to weeks",
+  },
+  {
+    feature: "Appointment Booking",
+    ai: "Automated, real-time",
+    traditional: "Manual, error-prone",
+  },
+  {
+    feature: "CRM Integration",
+    ai: "Native, automatic",
+    traditional: "Manual data entry",
+  },
+  {
+    feature: "Call Transcripts",
+    ai: "Every call, searchable",
+    traditional: "Rarely available",
+  },
+];
+
+const FAQS = [
+  {
+    q: "What is an AI receptionist?",
+    a: "An AI receptionist is a voice-powered virtual agent that answers phone calls on behalf of your business. It greets callers, answers frequently asked questions, schedules appointments, routes calls, and captures lead information — all without human intervention.",
+  },
+  {
+    q: "How does the AI receptionist handle complex or unexpected questions?",
+    a: "The AI is trained on your custom knowledge base and can answer a wide range of questions. When it encounters a request beyond its scope, it seamlessly transfers the call to a human team member or takes a message for follow-up.",
+  },
+  {
+    q: "Can I customize the greeting and voice?",
+    a: "Yes. You can fully customize the greeting script, hold music, voice tone, speaking pace, and language. The AI adapts to your brand personality so callers experience a consistent, professional interaction.",
+  },
+  {
+    q: "Is my data secure and HIPAA compliant?",
+    a: "Absolutely. QuickVoice uses end-to-end encryption, automatic PHI redaction, and role-based access controls. HIPAA-ready logging is available on the Scale plan, and we sign Business Associate Agreements on the Enterprise tier.",
+  },
+  {
+    q: "How long does it take to set up?",
+    a: "Most businesses are live within minutes. You configure your receptionist through a no-code dashboard, connect your phone number, and start receiving AI-answered calls right away. No coding or IT resources required.",
+  },
+  {
+    q: "Can the AI receptionist handle multiple calls at the same time?",
+    a: "Yes. Unlike a human receptionist, the AI can handle an unlimited number of concurrent calls. No caller ever gets a busy signal or has to wait on hold.",
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  JSON-LD Schemas                                                    */
+/* ------------------------------------------------------------------ */
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQS.map((faq) => ({
+    "@type": "Question",
+    name: faq.q,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.a,
+    },
+  })),
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://quickvoice.co",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Solutions",
+      item: "https://quickvoice.co/solutions",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "AI Receptionist",
+      item: "https://quickvoice.co/solutions/ai-receptionist",
+    },
+  ],
+};
+
+const webAppSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "QuickVoice AI Receptionist",
+  description:
+    "Deploy an AI receptionist that answers calls 24/7, books appointments, and routes callers automatically.",
+  url: "https://quickvoice.co/solutions/ai-receptionist",
+  applicationCategory: "BusinessApplication",
+  operatingSystem: "Web",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+    description: "Free trial available",
+  },
+  featureList: [
+    "24/7 automated call answering",
+    "Appointment scheduling",
+    "Intelligent call routing",
+    "100+ language support",
+    "HIPAA compliance",
+    "CRM integration",
+  ],
+};
+
+/* ================================================================== */
+/*  Page Component                                                     */
+/* ================================================================== */
+
+export default function AIReceptionistPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      {/* ── JSON-LD ─────────────────────────────────────────────── */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppSchema) }}
+      />
+
+      {/* ── Hero ────────────────────────────────────────────────── */}
+      <section className="relative overflow-hidden pt-24 pb-20 text-center">
+        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div className="absolute -top-[10%] left-1/2 h-[40%] w-[60%] -translate-x-1/2 rounded-full bg-primary/10 blur-3xl" />
+          <div className="absolute -bottom-[10%] -right-[10%] h-[40%] w-[40%] rounded-full bg-primary/5 blur-3xl" />
+        </div>
+
+        <div className="container mx-auto max-w-4xl px-4">
+          <nav aria-label="Breadcrumb" className="mb-8 flex items-center justify-center gap-1 text-sm text-muted-foreground">
+            <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
+            <ChevronRight className="h-3.5 w-3.5" />
+            <span>Solutions</span>
+            <ChevronRight className="h-3.5 w-3.5" />
+            <span className="text-foreground font-medium">AI Receptionist</span>
+          </nav>
+
+          <p className="mb-4 inline-block rounded-full border border-primary/20 bg-primary/5 px-4 py-1 text-sm font-medium text-primary">
+            AI Receptionist
+          </p>
+
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+            AI Receptionist — Automate{" "}
+            <span className="text-primary">Front Desk Calls 24/7</span>
+          </h1>
+
+          <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground">
+            Replace voicemail with an AI-powered virtual receptionist that
+            answers every call, books appointments, routes inquiries, and
+            captures leads — around the clock, in 100+ languages.
+          </p>
+
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/register"
+              className="inline-flex items-center justify-center rounded-lg bg-primary px-8 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            >
+              Start Free Trial
+            </Link>
+            <Link
+              href={DEMO_BOOKING_URL}
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-8 py-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
+            >
+              Book a Demo
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── How It Works ────────────────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-5xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            How It Works
+          </h2>
+          <p className="mx-auto mb-14 max-w-xl text-center text-muted-foreground">
+            Get your AI receptionist live in three simple steps — no coding
+            required.
+          </p>
+
+          <div className="grid gap-10 md:grid-cols-3">
+            {STEPS.map((step) => (
+              <div key={step.step} className="text-center">
+                <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <step.icon className="h-7 w-7" />
+                </div>
+                <div className="mb-2 inline-flex h-7 w-7 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                  {step.step}
+                </div>
+                <h3 className="mb-2 text-xl font-semibold">{step.title}</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {step.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Key Features ────────────────────────────────────────── */}
+      <section className="py-20">
+        <div className="container mx-auto max-w-6xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Key Features
+          </h2>
+          <p className="mx-auto mb-14 max-w-xl text-center text-muted-foreground">
+            Everything you need in a virtual receptionist, powered by
+            conversational AI.
+          </p>
+
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map((feature) => (
+              <div
+                key={feature.title}
+                className="rounded-2xl border border-border bg-background p-6 transition-shadow hover:shadow-lg"
+              >
+                <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <feature.icon className="h-5 w-5" />
+                </div>
+                <h3 className="mb-2 text-lg font-semibold">{feature.title}</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {feature.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Use Cases by Industry ───────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-6xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Use Cases by Industry
+          </h2>
+          <p className="mx-auto mb-14 max-w-xl text-center text-muted-foreground">
+            See how businesses across industries use an AI receptionist to
+            streamline front-desk operations.
+          </p>
+
+          <div className="grid gap-8 sm:grid-cols-2">
+            {USE_CASES.map((uc) => (
+              <div
+                key={uc.industry}
+                className="rounded-2xl border border-border bg-background p-6"
+              >
+                <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <uc.icon className="h-5 w-5" />
+                </div>
+                <h3 className="mb-2 text-lg font-semibold">{uc.industry}</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {uc.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── ROI Stats ───────────────────────────────────────────── */}
+      <section className="py-20">
+        <div className="container mx-auto max-w-5xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            The ROI of an AI Receptionist
+          </h2>
+          <p className="mx-auto mb-14 max-w-xl text-center text-muted-foreground">
+            Missing calls means missing revenue. Here is what the numbers say.
+          </p>
+
+          <div className="grid gap-8 md:grid-cols-3">
+            {ROI_STATS.map((item) => (
+              <div
+                key={item.stat}
+                className="rounded-2xl border border-border bg-background p-8 text-center"
+              >
+                <p className="text-4xl font-bold text-primary">{item.stat}</p>
+                <p className="mt-2 text-sm font-semibold">{item.label}</p>
+                <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
+                  {item.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Comparison Table ────────────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-4xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            AI Receptionist vs Traditional Answering Service
+          </h2>
+          <p className="mx-auto mb-14 max-w-xl text-center text-muted-foreground">
+            See why businesses are switching from legacy services to AI-powered
+            call answering.
+          </p>
+
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr>
+                  <th className="border-b border-border p-4 text-left font-medium text-muted-foreground">
+                    Feature
+                  </th>
+                  <th className="border-b border-primary bg-primary/5 p-4 text-center font-semibold">
+                    <div className="flex items-center justify-center gap-2">
+                      <Phone className="h-4 w-4 text-primary" />
+                      AI Receptionist
+                    </div>
+                  </th>
+                  <th className="border-b border-border p-4 text-center font-semibold">
+                    Traditional Service
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {COMPARISON_ROWS.map((row) => (
+                  <tr key={row.feature}>
+                    <td className="p-4 font-medium">{row.feature}</td>
+                    <td className="bg-primary/5 p-4 text-center">
+                      <span className="inline-flex items-center gap-1.5">
+                        <CheckCircle2 className="h-4 w-4 text-primary shrink-0" />
+                        {row.ai}
+                      </span>
+                    </td>
+                    <td className="p-4 text-center text-muted-foreground">
+                      <span className="inline-flex items-center gap-1.5">
+                        <XCircle className="h-4 w-4 text-muted-foreground/40 shrink-0" />
+                        {row.traditional}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ─────────────────────────────────────────────────── */}
+      <section className="py-20">
+        <div className="container mx-auto max-w-3xl px-4">
+          <h2 className="mb-2 text-center text-3xl font-bold tracking-tight">
+            Frequently Asked Questions
+          </h2>
+          <p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
+            Everything you need to know about QuickVoice&apos;s AI receptionist.
+          </p>
+
+          <dl className="divide-y divide-border">
+            {FAQS.map((faq) => (
+              <div key={faq.q} className="py-6">
+                <dt className="text-base font-semibold">{faq.q}</dt>
+                <dd className="mt-2 text-muted-foreground">{faq.a}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      {/* ── Bottom CTA ──────────────────────────────────────────── */}
+      <section className="border-t border-border bg-muted/30 py-20">
+        <div className="container mx-auto max-w-2xl px-4 text-center">
+          <h2 className="text-3xl font-bold tracking-tight">
+            Ready to Never Miss a Call Again?
+          </h2>
+          <p className="mx-auto mt-4 max-w-lg text-muted-foreground">
+            Deploy your AI receptionist in minutes. Start with a free trial — no
+            credit card required — or book a personalized demo with our team.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/register"
+              className="inline-flex items-center justify-center rounded-lg bg-primary px-8 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            >
+              Start Free Trial
+            </Link>
+            <Link
+              href={DEMO_BOOKING_URL}
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-8 py-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
+            >
+              Book a Demo
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/solutions/page.tsx
+++ b/apps/web/src/app/solutions/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, Bot, Headphones, CalendarCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DEMO_BOOKING_URL } from "@/lib/links";
+
+export const metadata: Metadata = {
+  title: "AI Voice Agent Solutions | QuickVoice",
+  description:
+    "Explore QuickVoice AI voice agent solutions for reception, call answering, appointment booking, routing, and front-office automation.",
+  alternates: {
+    canonical: "https://quickvoice.co/solutions",
+  },
+  openGraph: {
+    title: "AI Voice Agent Solutions | QuickVoice",
+    description:
+      "Explore QuickVoice AI voice agent solutions for reception, call answering, appointment booking, routing, and front-office automation.",
+    url: "https://quickvoice.co/solutions",
+    siteName: "QuickVoice",
+    type: "website",
+    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI Voice Agent Solutions | QuickVoice",
+    description:
+      "Explore QuickVoice AI voice agent solutions for reception, call answering, appointment booking, routing, and front-office automation.",
+    images: ["/og-image.png"],
+  },
+};
+
+const solutions = [
+  {
+    title: "AI Receptionist",
+    description:
+      "Answer calls 24/7, capture caller intent, schedule appointments, and route urgent conversations to the right person.",
+    href: "/solutions/ai-receptionist",
+    icon: Bot,
+  },
+  {
+    title: "AI Answering Service",
+    description:
+      "Replace missed calls and voicemail backlogs with instant, branded call handling that collects details and triggers follow-up.",
+    href: "/solutions/ai-answering-service",
+    icon: Headphones,
+  },
+  {
+    title: "Appointment Scheduling",
+    description:
+      "Let callers book, reschedule, confirm, or cancel appointments without waiting for staff to pick up.",
+    href: "/use-cases/appointment-scheduling",
+    icon: CalendarCheck,
+  },
+];
+
+export default function SolutionsPage() {
+  return (
+    <main className="bg-background text-foreground">
+      <section className="mx-auto flex min-h-[72vh] w-full max-w-7xl flex-col justify-center px-6 py-20 md:px-10">
+        <div className="max-w-3xl">
+          <p className="text-sm font-semibold uppercase text-primary">
+            QuickVoice solutions
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold md:text-6xl">
+            AI voice agents for every front-office call flow
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            Deploy voice agents that answer calls, qualify requests, book meetings,
+            and hand off complex conversations with transcripts and context.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button asChild size="lg">
+              <Link href={DEMO_BOOKING_URL}>Book a Demo</Link>
+            </Button>
+            <Button asChild size="lg" variant="outline">
+              <Link href="/pricing">View Pricing</Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-14 grid gap-4 md:grid-cols-3">
+          {solutions.map((solution) => {
+            const Icon = solution.icon;
+            return (
+              <Link
+                key={solution.href}
+                href={solution.href}
+                className="group rounded-lg border bg-card p-6 transition hover:border-primary/60 hover:shadow-sm"
+              >
+                <Icon className="h-6 w-6 text-primary" />
+                <h2 className="mt-5 text-xl font-semibold">{solution.title}</h2>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                  {solution.description}
+                </p>
+                <span className="mt-5 inline-flex items-center gap-2 text-sm font-medium text-primary">
+                  Explore <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/terms-of-service/page.tsx
+++ b/apps/web/src/app/terms-of-service/page.tsx
@@ -1,0 +1,732 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { DEMO_BOOKING_URL } from "@/lib/links";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "QuickVoice Terms of Service — usage terms, acceptable use policy, billing, liability, and your rights when using our AI voice agent platform.",
+  alternates: {
+    canonical: "https://quickvoice.co/terms-of-service",
+  },
+  openGraph: {
+    title: "Terms of Service",
+    description:
+      "QuickVoice Terms of Service — usage terms, acceptable use, and your rights.",
+    type: "website",
+    url: "https://quickvoice.co/terms-of-service",
+    siteName: "QuickVoice",
+  },
+  twitter: {
+    card: "summary",
+    title: "Terms of Service | QuickVoice",
+    description:
+      "QuickVoice Terms of Service — usage terms, acceptable use, and your rights.",
+  },
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <main className="bg-background text-foreground">
+      <div className="mx-auto max-w-4xl px-6 py-20 sm:py-28">
+        {/* Header */}
+        <header className="mb-16">
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+            Terms of Service
+          </h1>
+          <p className="mt-4 text-muted-foreground">
+            Last updated: February 2026
+          </p>
+        </header>
+
+        {/* Content */}
+        <div className="space-y-12 text-base leading-7">
+          {/* 1. Acceptance of Terms */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              1. Acceptance of Terms
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                Welcome to QuickVoice. By accessing or using the QuickVoice
+                platform, website, APIs, or any associated services
+                (collectively, the &ldquo;Services&rdquo;), you agree to be
+                bound by these Terms of Service (&ldquo;Terms&rdquo;). If you
+                are using the Services on behalf of an organization, you
+                represent and warrant that you have the authority to bind that
+                organization to these Terms, and references to &ldquo;you&rdquo;
+                or &ldquo;your&rdquo; shall include that organization.
+              </p>
+              <p>
+                If you do not agree to these Terms, you must not access or use
+                the Services. Your continued use of the Services following any
+                changes to these Terms constitutes acceptance of those changes.
+              </p>
+            </div>
+          </section>
+
+          {/* 2. Description of Services */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              2. Description of Services
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                QuickVoice provides an AI-powered voice agent platform that
+                enables businesses to create, deploy, and manage intelligent
+                voice agents for automated phone conversations. Our Services
+                include, but are not limited to:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  AI voice agent creation, configuration, and deployment tools
+                </li>
+                <li>
+                  Inbound and outbound automated voice call handling
+                </li>
+                <li>
+                  Integration with third-party telephony, CRM, and business
+                  systems
+                </li>
+                <li>
+                  Call analytics, transcription, and reporting dashboards
+                </li>
+                <li>
+                  API access for programmatic voice agent management
+                </li>
+                <li>
+                  Knowledge base management and voice agent training tools
+                </li>
+              </ul>
+              <p>
+                QuickVoice reserves the right to modify, suspend, or
+                discontinue any part of the Services at any time with reasonable
+                notice. We will make commercially reasonable efforts to notify
+                you of material changes that affect your use of the Services.
+              </p>
+            </div>
+          </section>
+
+          {/* 3. Account Registration and Security */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              3. Account Registration and Security
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                To use certain features of the Services, you must create an
+                account. When registering, you agree to:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  Provide accurate, current, and complete information during
+                  registration and keep your account information up to date
+                </li>
+                <li>
+                  Create a strong password and maintain the confidentiality of
+                  your login credentials
+                </li>
+                <li>
+                  Accept responsibility for all activities that occur under your
+                  account, whether or not authorized by you
+                </li>
+                <li>
+                  Notify QuickVoice immediately at{" "}
+                  <a
+                    href="mailto:support@quickvoice.co"
+                    className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+                  >
+                    support@quickvoice.co
+                  </a>{" "}
+                  if you suspect unauthorized access to or use of your account
+                </li>
+                <li>
+                  Not share, transfer, or sell your account credentials to any
+                  third party
+                </li>
+              </ul>
+              <p>
+                QuickVoice reserves the right to suspend or terminate accounts
+                that violate these Terms or that have been inactive for an
+                extended period, in accordance with applicable law and with
+                reasonable notice where practicable.
+              </p>
+            </div>
+          </section>
+
+          {/* 4. Subscription Plans and Payments */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              4. Subscription Plans and Payments
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                QuickVoice offers various subscription plans, including free
+                tiers and paid plans. By subscribing to a paid plan, you agree
+                to the following:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  <strong className="text-foreground">Billing Cycle:</strong>{" "}
+                  Paid subscriptions are billed on a recurring basis (monthly or
+                  annually) depending on the plan you select. Billing begins on
+                  the date you subscribe and recurs on the same date each
+                  billing period.
+                </li>
+                <li>
+                  <strong className="text-foreground">Payment Method:</strong>{" "}
+                  You must provide a valid payment method. By providing a
+                  payment method, you authorize QuickVoice to charge all fees
+                  incurred to that payment method.
+                </li>
+                <li>
+                  <strong className="text-foreground">Price Changes:</strong>{" "}
+                  QuickVoice may change subscription pricing with at least 30
+                  days&apos; prior notice. Price changes take effect at the
+                  start of your next billing period following the notice.
+                </li>
+                <li>
+                  <strong className="text-foreground">Usage-Based Charges:</strong>{" "}
+                  Certain Services may include usage-based components (e.g.,
+                  per-minute call charges, additional voice agent deployments).
+                  These charges are billed in arrears and detailed on your
+                  invoice.
+                </li>
+                <li>
+                  <strong className="text-foreground">Refunds:</strong>{" "}
+                  Subscription fees are generally non-refundable except as
+                  required by applicable law or as expressly stated in your plan
+                  terms. If you cancel a subscription, you retain access to paid
+                  features until the end of your current billing period.
+                </li>
+                <li>
+                  <strong className="text-foreground">Taxes:</strong> All fees
+                  are exclusive of applicable taxes unless stated otherwise. You
+                  are responsible for any taxes associated with your use of the
+                  Services, excluding taxes based on QuickVoice&apos;s net
+                  income.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          {/* 5. Acceptable Use Policy */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              5. Acceptable Use Policy
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                You agree to use the Services only for lawful purposes and in
+                accordance with these Terms. You shall not use the Services to:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  Violate any applicable local, state, national, or
+                  international law or regulation, including but not limited to
+                  the Telephone Consumer Protection Act (TCPA), telemarketing
+                  laws, and do-not-call regulations
+                </li>
+                <li>
+                  Make automated calls or send communications without obtaining
+                  proper consent from recipients as required by applicable law
+                </li>
+                <li>
+                  Engage in fraudulent, deceptive, or misleading practices,
+                  including misrepresenting the AI nature of voice agents where
+                  disclosure is required by law
+                </li>
+                <li>
+                  Harass, abuse, threaten, or intimidate any person through
+                  voice agents or any other use of the Services
+                </li>
+                <li>
+                  Transmit or facilitate the distribution of malware, viruses,
+                  or other harmful code
+                </li>
+                <li>
+                  Attempt to gain unauthorized access to any part of the
+                  Services, other accounts, or any systems or networks connected
+                  to the Services
+                </li>
+                <li>
+                  Reverse engineer, decompile, disassemble, or otherwise attempt
+                  to derive the source code of the Services
+                </li>
+                <li>
+                  Use the Services in a manner that could overburden, impair, or
+                  compromise the infrastructure or interfere with other
+                  users&apos; use of the Services
+                </li>
+                <li>
+                  Resell, sublicense, or redistribute the Services without
+                  QuickVoice&apos;s prior written consent
+                </li>
+                <li>
+                  Use the Services to collect, store, or process sensitive
+                  personal information (such as health or financial data) in
+                  violation of applicable privacy laws
+                </li>
+              </ul>
+              <p>
+                QuickVoice reserves the right to investigate and take
+                appropriate action against violations of this Acceptable Use
+                Policy, including suspending or terminating your access to the
+                Services and reporting conduct to law enforcement authorities.
+              </p>
+            </div>
+          </section>
+
+          {/* 6. Intellectual Property */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              6. Intellectual Property
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                <strong className="text-foreground">
+                  QuickVoice&apos;s Intellectual Property:
+                </strong>{" "}
+                The Services, including all software, algorithms, AI models,
+                user interface designs, documentation, trademarks, logos, and
+                other materials, are owned by or licensed to QuickVoice and are
+                protected by copyright, trademark, patent, trade secret, and
+                other intellectual property laws. Nothing in these Terms grants
+                you any right, title, or interest in the Services except for
+                the limited right to use the Services as expressly permitted
+                under these Terms.
+              </p>
+              <p>
+                <strong className="text-foreground">Your Content:</strong> You
+                retain ownership of all data, content, scripts, prompts, and
+                configurations that you upload, create, or input into the
+                Services (&ldquo;Your Content&rdquo;). By using the Services,
+                you grant QuickVoice a limited, non-exclusive, worldwide,
+                royalty-free license to use, process, and store Your Content
+                solely for the purpose of providing and improving the Services.
+              </p>
+              <p>
+                <strong className="text-foreground">Feedback:</strong> If you
+                provide suggestions, ideas, or feedback about the Services
+                (&ldquo;Feedback&rdquo;), you grant QuickVoice a perpetual,
+                irrevocable, royalty-free license to use, modify, and
+                incorporate that Feedback into the Services without any
+                obligation to you.
+              </p>
+            </div>
+          </section>
+
+          {/* 7. Data Privacy */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              7. Data Privacy
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                Your privacy is important to us. Our collection, use, and
+                disclosure of personal information in connection with the
+                Services is described in our{" "}
+                <a
+                  href="/privacy-policy"
+                  className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+                >
+                  Privacy Policy
+                </a>
+                , which is incorporated into these Terms by reference.
+              </p>
+              <p>
+                By using the Services, you acknowledge and agree that:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  QuickVoice may collect and process voice data, call
+                  recordings, transcripts, and metadata as part of delivering
+                  the Services
+                </li>
+                <li>
+                  You are responsible for complying with all applicable data
+                  protection and privacy laws when using the Services, including
+                  obtaining necessary consents from individuals whose data is
+                  processed through your voice agents
+                </li>
+                <li>
+                  You will not use the Services to process personal data in a
+                  manner that violates applicable law or any data processing
+                  agreement between you and QuickVoice
+                </li>
+                <li>
+                  Where required, QuickVoice will enter into appropriate data
+                  processing agreements to support your compliance with
+                  applicable data protection regulations (such as GDPR or CCPA)
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          {/* 8. Service Availability and SLA */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              8. Service Availability and SLA
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                QuickVoice strives to maintain high availability of the
+                Services. While we target 99.9% uptime for our production
+                infrastructure, we do not guarantee uninterrupted or error-free
+                operation. Specifically:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  <strong className="text-foreground">
+                    Scheduled Maintenance:
+                  </strong>{" "}
+                  QuickVoice may perform scheduled maintenance that temporarily
+                  affects availability. We will provide reasonable advance
+                  notice of scheduled maintenance windows.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    Unscheduled Downtime:
+                  </strong>{" "}
+                  In the event of unscheduled outages, QuickVoice will use
+                  commercially reasonable efforts to restore the Services as
+                  quickly as possible and communicate status updates through our
+                  status page.
+                </li>
+                <li>
+                  <strong className="text-foreground">SLA Credits:</strong>{" "}
+                  Customers on eligible paid plans may be entitled to service
+                  credits for downtime that exceeds the uptime commitment
+                  specified in their service agreement. Details of SLA credits
+                  are outlined in the applicable plan documentation.
+                </li>
+                <li>
+                  <strong className="text-foreground">Exclusions:</strong>{" "}
+                  Uptime commitments do not apply to outages caused by factors
+                  outside QuickVoice&apos;s reasonable control, including
+                  internet connectivity issues, third-party service failures,
+                  force majeure events, or your misuse of the Services.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          {/* 9. Limitation of Liability */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              9. Limitation of Liability
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                To the maximum extent permitted by applicable law:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  <strong className="text-foreground">
+                    No Indirect Damages:
+                  </strong>{" "}
+                  In no event shall QuickVoice, its affiliates, officers,
+                  directors, employees, or agents be liable for any indirect,
+                  incidental, special, consequential, or punitive damages,
+                  including but not limited to loss of profits, revenue, data,
+                  business opportunities, or goodwill, arising out of or in
+                  connection with these Terms or your use of the Services,
+                  regardless of the theory of liability.
+                </li>
+                <li>
+                  <strong className="text-foreground">Liability Cap:</strong>{" "}
+                  QuickVoice&apos;s total aggregate liability for all claims
+                  arising out of or related to these Terms or the Services shall
+                  not exceed the greater of (a) the total fees you paid to
+                  QuickVoice during the twelve (12) months immediately preceding
+                  the event giving rise to the claim, or (b) one hundred US
+                  dollars ($100).
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    AI-Generated Content:
+                  </strong>{" "}
+                  The Services utilize artificial intelligence to generate voice
+                  responses. QuickVoice does not guarantee the accuracy,
+                  completeness, or appropriateness of AI-generated content. You
+                  acknowledge that AI voice agents may occasionally produce
+                  errors, and you are responsible for monitoring and reviewing
+                  interactions as appropriate for your use case.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    No Warranty:
+                  </strong>{" "}
+                  The Services are provided on an &ldquo;as is&rdquo; and
+                  &ldquo;as available&rdquo; basis without warranties of any
+                  kind, whether express, implied, or statutory, including but
+                  not limited to implied warranties of merchantability, fitness
+                  for a particular purpose, and non-infringement.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          {/* 10. Indemnification */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              10. Indemnification
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                You agree to indemnify, defend, and hold harmless QuickVoice,
+                its affiliates, officers, directors, employees, agents, and
+                licensors from and against any and all claims, liabilities,
+                damages, losses, costs, and expenses (including reasonable
+                attorneys&apos; fees) arising out of or related to:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>Your use or misuse of the Services</li>
+                <li>Your violation of these Terms</li>
+                <li>
+                  Your violation of any applicable law, regulation, or
+                  third-party right, including privacy, telecommunications, and
+                  consumer protection laws
+                </li>
+                <li>
+                  Your Content or any data you process through the Services
+                </li>
+                <li>
+                  Any claims made by third parties in connection with calls or
+                  communications initiated through your voice agents
+                </li>
+              </ul>
+              <p>
+                QuickVoice reserves the right to assume the exclusive defense
+                and control of any matter subject to indemnification by you, in
+                which case you agree to cooperate with QuickVoice in asserting
+                any available defenses.
+              </p>
+            </div>
+          </section>
+
+          {/* 11. Termination */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              11. Termination
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                Either party may terminate these Terms as follows:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  <strong className="text-foreground">By You:</strong> You may
+                  terminate your account at any time by contacting us at{" "}
+                  <a
+                    href="mailto:support@quickvoice.co"
+                    className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+                  >
+                    support@quickvoice.co
+                  </a>{" "}
+                  or through the account settings in the platform. Cancellation
+                  takes effect at the end of your current billing period.
+                </li>
+                <li>
+                  <strong className="text-foreground">By QuickVoice:</strong>{" "}
+                  QuickVoice may suspend or terminate your access to the
+                  Services immediately and without prior notice if you breach
+                  these Terms, engage in conduct that is harmful to other users
+                  or the Services, or if required to do so by law. For
+                  non-breach terminations, QuickVoice will provide at least 30
+                  days&apos; notice.
+                </li>
+              </ul>
+              <p>
+                Upon termination:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  Your right to access and use the Services will cease
+                  immediately (or at the end of your billing period, as
+                  applicable)
+                </li>
+                <li>
+                  QuickVoice will make Your Content available for export for a
+                  period of 30 days following termination, after which it may be
+                  permanently deleted
+                </li>
+                <li>
+                  Sections of these Terms that by their nature should survive
+                  termination will survive, including intellectual property,
+                  limitation of liability, indemnification, and governing law
+                  provisions
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          {/* 12. Governing Law and Dispute Resolution */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              12. Governing Law and Dispute Resolution
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                These Terms shall be governed by and construed in accordance
+                with the laws of the State of Delaware, United States, without
+                regard to its conflict-of-law principles.
+              </p>
+              <p>
+                Any dispute, controversy, or claim arising out of or relating to
+                these Terms or the Services shall first be resolved through good
+                faith negotiation between the parties. If the dispute cannot be
+                resolved through negotiation within 30 days, either party may
+                submit the dispute to binding arbitration administered by the
+                American Arbitration Association (AAA) under its Commercial
+                Arbitration Rules.
+              </p>
+              <p>
+                The arbitration shall be conducted in English and take place in
+                Wilmington, Delaware, unless the parties mutually agree to an
+                alternative location or virtual proceedings. The
+                arbitrator&apos;s decision shall be final and binding and may be
+                entered as a judgment in any court of competent jurisdiction.
+              </p>
+              <p>
+                To the extent permitted by law, you agree that any claims shall
+                be brought in your individual capacity and not as a plaintiff or
+                class member in any purported class action, collective action,
+                or representative proceeding.
+              </p>
+            </div>
+          </section>
+
+          {/* 13. Changes to Terms */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              13. Changes to Terms
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                QuickVoice reserves the right to update or modify these Terms at
+                any time. When we make changes, we will:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  Update the &ldquo;Last updated&rdquo; date at the top of this
+                  page
+                </li>
+                <li>
+                  Notify you of material changes via email to the address
+                  associated with your account or through an in-platform
+                  notification at least 30 days before the changes take effect
+                </li>
+                <li>
+                  Provide a summary of significant changes for your convenience
+                </li>
+              </ul>
+              <p>
+                Your continued use of the Services after the effective date of
+                revised Terms constitutes your acceptance of the changes. If you
+                do not agree to the revised Terms, you must stop using the
+                Services and may terminate your account in accordance with
+                Section 11.
+              </p>
+            </div>
+          </section>
+
+          {/* 14. General Provisions */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              14. General Provisions
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                <strong className="text-foreground">Entire Agreement:</strong>{" "}
+                These Terms, together with the Privacy Policy and any applicable
+                order forms or service agreements, constitute the entire
+                agreement between you and QuickVoice regarding the Services and
+                supersede all prior agreements and understandings.
+              </p>
+              <p>
+                <strong className="text-foreground">Severability:</strong> If
+                any provision of these Terms is held to be invalid or
+                unenforceable, the remaining provisions shall continue in full
+                force and effect, and the invalid provision shall be modified to
+                the minimum extent necessary to make it valid and enforceable.
+              </p>
+              <p>
+                <strong className="text-foreground">Waiver:</strong> The
+                failure of QuickVoice to enforce any right or provision of these
+                Terms shall not constitute a waiver of that right or provision.
+              </p>
+              <p>
+                <strong className="text-foreground">Assignment:</strong> You may
+                not assign or transfer these Terms or your rights under them
+                without QuickVoice&apos;s prior written consent. QuickVoice may
+                assign these Terms in connection with a merger, acquisition, or
+                sale of all or substantially all of its assets.
+              </p>
+              <p>
+                <strong className="text-foreground">Force Majeure:</strong>{" "}
+                QuickVoice shall not be liable for any failure or delay in
+                performing its obligations under these Terms due to
+                circumstances beyond its reasonable control, including natural
+                disasters, war, terrorism, pandemics, strikes, government
+                actions, or failures of third-party services or infrastructure.
+              </p>
+            </div>
+          </section>
+
+          {/* 15. Contact Information */}
+          <section>
+            <h2 className="text-2xl font-semibold tracking-tight">
+              15. Contact Information
+            </h2>
+            <div className="mt-4 space-y-4 text-muted-foreground">
+              <p>
+                If you have any questions, concerns, or requests regarding these
+                Terms of Service, please contact us at:
+              </p>
+              <div className="mt-2">
+                <p className="font-medium text-foreground">QuickVoice</p>
+                <p>
+                  Email:{" "}
+                  <a
+                    href="mailto:support@quickvoice.co"
+                    className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+                  >
+                    support@quickvoice.co
+                  </a>
+                </p>
+                <p>
+                  Website:{" "}
+                  <a
+                    href="https://quickvoice.co"
+                    className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+                  >
+                    https://quickvoice.co
+                  </a>
+                </p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <section className="border-t border-border bg-muted/30 py-12">
+        <div className="mx-auto max-w-4xl px-6 text-center">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            Want to review terms before rollout?
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
+            Schedule a demo to walk through onboarding, billing, usage, and
+            compliance expectations with a QuickVoice specialist.
+          </p>
+          <Link
+            href={DEMO_BOOKING_URL}
+            className="mt-6 inline-flex items-center justify-center rounded-lg bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+          >
+            Book a Demo
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/use-cases/page.tsx
+++ b/apps/web/src/app/use-cases/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import {
+  UseCasesHeroSection,
+  UseCasesGridSection,
+  UseCasesCtaSection,
+} from "@/components/landing/usecases-main";
+
+export const metadata: Metadata = {
+  title: "AI Voice Agent Use Cases — Support, Scheduling, Sales",
+  description:
+    "Automate customer support, appointment scheduling, outbound sales, order tracking, collections, and HR screening with QuickVoice AI voice agents. No-code. Free trial.",
+  alternates: {
+    canonical: "https://quickvoice.co/use-cases",
+  },
+  openGraph: {
+    title: "AI Voice Agent Use Cases",
+    description:
+      "Explore how QuickVoice AI voice agents automate support, scheduling, sales, collections, and more. HIPAA compliant. 100+ languages.",
+    type: "website",
+    url: "https://quickvoice.co/use-cases",
+    siteName: "QuickVoice",
+    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI Voice Agent Use Cases",
+    description:
+      "Explore how QuickVoice AI voice agents automate support, scheduling, sales, collections, and more. HIPAA compliant. 100+ languages.",
+    images: ["/og-image.png"],
+  },
+};
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "AI Voice Agent Use Cases | QuickVoice",
+  description:
+    "Discover how QuickVoice's AI-powered voice agents automate workflows, enhance customer experiences, and drive operational efficiency across customer support, sales, scheduling, and more.",
+  url: "https://quickvoice.co/use-cases",
+  mainEntity: {
+    "@type": "SoftwareApplication",
+    name: "QuickVoice",
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  },
+  breadcrumb: {
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://quickvoice.co",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Use Cases",
+        item: "https://quickvoice.co/use-cases",
+      },
+    ],
+  },
+};
+
+export default function UseCasesPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <UseCasesHeroSection />
+      <UseCasesGridSection />
+      <UseCasesCtaSection />
+    </div>
+  );
+}

--- a/apps/web/src/components/mvpblocks/feature-1.tsx
+++ b/apps/web/src/components/mvpblocks/feature-1.tsx
@@ -17,26 +17,29 @@ import {
 import { cn } from "@/lib/utils";
 
 const useAnimationFrame = (callback: (time: number, delta: number) => void) => {
-  const requestRef = useRef<number | null>(null);
-  const previousTimeRef = useRef<number | null>(null);
+  const callbackRef = useRef(callback);
 
-  const animate = useCallback((time: number) => {
-    if (previousTimeRef.current !== null && previousTimeRef.current !== undefined) {
-      const delta = time - previousTimeRef.current;
-      callback(time, delta);
-    }
-    previousTimeRef.current = time;
-    requestRef.current = requestAnimationFrame(animate);
+  useEffect(() => {
+    callbackRef.current = callback;
   }, [callback]);
 
   useEffect(() => {
-    requestRef.current = requestAnimationFrame(animate);
-    return () => {
-      if (requestRef.current) {
-        cancelAnimationFrame(requestRef.current);
+    let requestId: number;
+    let previousTime: number | null = null;
+
+    const animate = (time: number) => {
+      if (previousTime !== null) {
+        callbackRef.current(time, time - previousTime);
       }
+      previousTime = time;
+      requestId = requestAnimationFrame(animate);
     };
-  }, [animate]);
+
+    requestId = requestAnimationFrame(animate);
+    return () => {
+      cancelAnimationFrame(requestId);
+    };
+  }, []);
 };
 
 interface MarqueeProps extends React.ComponentPropsWithoutRef<"div"> {

--- a/apps/web/src/components/mvpblocks/header-1.tsx
+++ b/apps/web/src/components/mvpblocks/header-1.tsx
@@ -10,6 +10,7 @@ import {
 import Link from "next/link";
 import { Button } from "../ui/button";
 import Logo1 from "../logo1";
+import { DEMO_BOOKING_URL } from "@/lib/links";
 
 interface NavItem {
   name: string;
@@ -30,6 +31,16 @@ const navItems: NavItem[] = [
     href: "#",
     hasDropdown: true,
     dropdownItems: [
+      {
+        name: "Voice Agent Solutions",
+        href: "/solutions",
+        hasNestedDropdown: true,
+        nestedDropdownItems: [
+          { name: "Solutions Overview", href: "/solutions" },
+          { name: "AI Receptionist", href: "/solutions/ai-receptionist" },
+          { name: "AI Answering Service", href: "/solutions/ai-answering-service" },
+        ],
+      },
       {
         name: "Industries",
         href: "/industries",
@@ -218,6 +229,9 @@ export default function Header1() {
               <Button variant="ghost" asChild>
                 <Link href="/login">Log in</Link>
               </Button>
+              <Button variant="outline" asChild>
+                <Link href={DEMO_BOOKING_URL}>Book a Demo</Link>
+              </Button>
               <Button asChild>
                 <Link href="/register">Get Started</Link>
               </Button>
@@ -338,6 +352,9 @@ export default function Header1() {
             <div className="flex flex-col gap-2 mt-4 pt-4 border-t border-border">
               <Button variant="outline" asChild className="w-full">
                 <Link href="/login" onClick={() => setIsMobileMenuOpen(false)}>Log in</Link>
+              </Button>
+              <Button variant="outline" asChild className="w-full">
+                <Link href={DEMO_BOOKING_URL} onClick={() => setIsMobileMenuOpen(false)}>Book a Demo</Link>
               </Button>
               <Button asChild className="w-full">
                 <Link href="/register" onClick={() => setIsMobileMenuOpen(false)}>Get Started</Link>

--- a/apps/web/src/lib/links.ts
+++ b/apps/web/src/lib/links.ts
@@ -1,0 +1,1 @@
+export const DEMO_BOOKING_URL = "https://tidycal.com/team/quickvoice/demo";


### PR DESCRIPTION
## Summary
- Add public marketing SEO pages for pricing, solutions, legal pages, and use-cases hub
- Add centralized TidyCal demo booking URL and global navbar Book a Demo CTA
- Add new solution routes to the sitemap and fix a React compiler lint issue blocking web verification

## Test Plan
- pnpm --filter web lint
- pnpm --filter web build
- HTTP smoke checks for /, /pricing, /solutions, /solutions/ai-receptionist, /solutions/ai-answering-service, /use-cases, /privacy-policy, and /terms-of-service