### PR TITLE
[codex] fix console login auth config

### DIFF
--- a/apps/console/src/components/forms/auth/login-form.tsx
+++ b/apps/console/src/components/forms/auth/login-form.tsx
@@ -9,7 +9,6 @@ import Link from "next/link";
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -30,6 +29,7 @@ import {
 import OAuthButtons from "@/src/components/oauth-buttons";
 
 export function LoginForm() {
+  const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
@@ -55,6 +55,8 @@ export function LoginForm() {
       setError(error.message || "Something went wrong");
     } else {
       toast.success("Login successful");
+      router.push("/dashboard");
+      router.refresh();
     }
     setLoading(false);
   };

--- a/apps/console/src/components/shell/PageActionsSlot.tsx
+++ b/apps/console/src/components/shell/PageActionsSlot.tsx
@@ -4,8 +4,8 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
-  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -40,11 +40,11 @@ export function usePageActionsSlot() {
 // Helper component pages can render to register topbar CTAs.
 export function PageActions({ children }: { children: ReactNode }) {
   const { setSlot } = usePageActionsSlot();
-  // One-time registration on mount via a ref to avoid re-runs on parent re-renders.
-  const registered = useRef(false);
-  if (!registered.current) {
+
+  useEffect(() => {
     setSlot(children);
-    registered.current = true;
-  }
+    return () => setSlot(null);
+  }, [children, setSlot]);
+
   return null;
 }

--- a/apps/console/src/index.d.ts
+++ b/apps/console/src/index.d.ts
@@ -22,7 +22,7 @@ declare global {
         slug: string;
         createdAt: Date;
         members: Member[];
-        invitations: any[];
+        invitations: unknown[];
     }
 
 }

--- a/apps/console/src/lib/auth-client.ts
+++ b/apps/console/src/lib/auth-client.ts
@@ -1,22 +1,31 @@
 import { createAuthClient } from "better-auth/react";
 import { inferAdditionalFields } from "better-auth/client/plugins";
-import { adminClient } from "better-auth/client/plugins"
-import { apiKeyClient } from "@better-auth/api-key/client"
-import { organizationClient } from "better-auth/client/plugins"
-import { stripeClient } from "@better-auth/stripe/client"
+import { adminClient } from "better-auth/client/plugins";
+import { apiKeyClient } from "@better-auth/api-key/client";
+import { organizationClient } from "better-auth/client/plugins";
+import { stripeClient } from "@better-auth/stripe/client";
+import type { auth } from "../../../server/src/lib/auth";
 
-import { auth } from "../../../server/src/lib/auth";
+const authBaseUrl =
+  process.env.NEXT_PUBLIC_BETTER_AUTH_URL ?? "http://localhost:5000";
+const apiVersion = process.env.NEXT_PUBLIC_API_VERSION ?? "v1";
+
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL!,
-  basePath: `/api/${process.env.NEXT_PUBLIC_API_VERSION! || "v1"}/auth`,
-  plugins: [inferAdditionalFields<typeof auth>(), adminClient(), apiKeyClient(), organizationClient({
-    dynamicAccessControl: {
-      enabled: true,
-    }
-  }), stripeClient({
-    subscription: true //if you want to enable subscription management
-  })],
+  baseURL: authBaseUrl,
+  basePath: `/api/${apiVersion}/auth`,
+  plugins: [
+    inferAdditionalFields<typeof auth>(),
+    adminClient(),
+    apiKeyClient(),
+    organizationClient({
+      dynamicAccessControl: {
+        enabled: true,
+      },
+    }),
+    stripeClient({
+      subscription: true,
+    }),
+  ],
 });
 
 export const { signIn, signUp, signOut, useSession } = authClient;
-

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -51,7 +51,7 @@ app.use(helmet());
 // CORS
 app.use(
   cors({
-    origin: "http://localhost:3000",
+    origin: process.env.CLIENT_URL || "http://localhost:3000",
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH"],
     credentials: true,
   })

--- a/apps/server/src/middleware/auth.middleware.ts
+++ b/apps/server/src/middleware/auth.middleware.ts
@@ -142,7 +142,8 @@ function getStringValue(value: unknown): string | null {
 function getBearerToken(value: string | undefined): string | null {
   const match = value?.match(/^Bearer\s+(.+)$/i);
   if (!match) return null;
-  return match[1].replace(/^Bearer\s+/i, "").trim();
+  const token = match[1];
+  return token ? token.replace(/^Bearer\s+/i, "").trim() : null;
 }
 
 function normalizeMetadata(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- Fix console Better Auth client config so client bundles no longer runtime-import server auth code.
- Add localhost auth server fallback and make Express CORS honor `CLIENT_URL`.
- Navigate and refresh after successful login, plus small type/lint fixes required by verification.

## Root Cause
The login client imported the server `auth` object as a runtime import and had no safe local fallback for `NEXT_PUBLIC_BETTER_AUTH_URL`, which could break client bundling and point auth requests at the wrong origin.

## Test Plan
- `npx -y pnpm@9.0.0 --filter dashboard lint`
- `npx -y pnpm@9.0.0 --filter dashboard build`
- `npx -y pnpm@9.0.0 --filter server check-types`