### PR TITLE
[codex] Fix ZeptoMail auth email sending

### DIFF
--- a/apps/server/src/lib/mailer.ts
+++ b/apps/server/src/lib/mailer.ts
@@ -1,5 +1,3 @@
-import { SendMailClient } from "zeptomail";
-
 type AuthEmailType = "verifyEmail" | "resetPassword";
 
 interface EmailContent {
@@ -18,13 +16,45 @@ function requireEnv(name: string) {
 }
 
 function getZeptoMailToken() {
-  const token =  process.env.SMTP_PASSWORD;
+  const token = process.env.ZEPTOMAIL_TOKEN || process.env.SMTP_PASSWORD;
   if (!token) {
     throw new Error(
       "Missing required email environment variable: ZEPTOMAIL_TOKEN or SMTP_PASSWORD",
     );
   }
   return token;
+}
+
+function getZeptoMailEndpoint() {
+  const rawUrl = process.env.ZEPTOMAIL_URL || process.env.SMTP_HOST;
+  if (!rawUrl) {
+    throw new Error(
+      "Missing required email environment variable: ZEPTOMAIL_URL or SMTP_HOST",
+    );
+  }
+
+  const urlWithProtocol = /^https?:\/\//i.test(rawUrl)
+    ? rawUrl
+    : `https://${rawUrl}`;
+  const endpoint = new URL(urlWithProtocol);
+
+  if (endpoint.hostname.startsWith("smtp.zeptomail.")) {
+    endpoint.hostname = endpoint.hostname.replace(/^smtp\./, "api.");
+  }
+
+  const path = endpoint.pathname.replace(/\/+$/, "");
+  if (!path) {
+    endpoint.pathname = "/v1.1/email";
+  } else if (path === "/v1.1") {
+    endpoint.pathname = "/v1.1/email";
+  } else {
+    endpoint.pathname = path;
+  }
+
+  endpoint.search = "";
+  endpoint.hash = "";
+
+  return endpoint.toString();
 }
 
 function escapeHtml(value: string) {
@@ -95,13 +125,6 @@ function buildHtml(content: EmailContent, url: string, fullName: string) {
 </html>`;
 }
 
-function createClient() {
-  return new SendMailClient({
-    url: process.env.SMTP_HOST! ,
-    token: getZeptoMailToken(),
-  });
-}
-
 export async function sendEmail(
   type: AuthEmailType,
   email: string,
@@ -110,9 +133,9 @@ export async function sendEmail(
 ) {
   const content = contentFor(type);
   const fromEmail = requireEnv("FROM_EMAIL");
-  const fromName = "Console|Quickvoice" ;
+  const fromName = "Console|Quickvoice";
 
-  await createClient().sendMail({
+  const payload = {
     from: {
       address: fromEmail,
       name: fromName,
@@ -128,5 +151,26 @@ export async function sendEmail(
     subject: content.subject,
     textbody: buildText(content, url, fullName),
     htmlbody: buildHtml(content, url, fullName),
-  });
+  };
+
+  try {
+    const response = await fetch(getZeptoMailEndpoint(), {
+      method: "POST",
+      headers: {
+        Authorization: getZeptoMailToken(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    const body = await response.text();
+
+    if (!response.ok) {
+      throw new Error(
+        `ZeptoMail responded with ${response.status} ${response.statusText}: ${body}`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to send ${type} email via ZeptoMail: ${message}`);
+  }
 }

--- a/apps/server/tests/mailer.test.ts
+++ b/apps/server/tests/mailer.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { sendEmail } from "../src/lib/mailer.js";
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  globalThis.fetch = originalFetch;
+});
+
+function setEmailEnv() {
+  process.env.SMTP_HOST = "smtp.zeptomail.in";
+  process.env.SMTP_PASSWORD = "test-token";
+  process.env.FROM_EMAIL = "no-reply@mail.quickvoice.co";
+}
+
+test("sendEmail derives the ZeptoMail API endpoint from the SMTP host", async () => {
+  setEmailEnv();
+
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  await sendEmail(
+    "verifyEmail",
+    "ada@example.com",
+    "https://console.quickvoice.co/verify",
+    "Ada",
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.zeptomail.in/v1.1/email");
+  assert.equal(calls[0].init?.method, "POST");
+  const headers = calls[0].init?.headers as Record<string, string>;
+  assert.equal(headers.Authorization, "test-token");
+});
+
+test("sendEmail rejects with a controlled error when ZeptoMail transport fails", async () => {
+  setEmailEnv();
+  globalThis.fetch = (async () => {
+    throw new TypeError("fetch failed");
+  }) as typeof fetch;
+
+  await assert.rejects(
+    sendEmail(
+      "resetPassword",
+      "ada@example.com",
+      "https://console.quickvoice.co/reset",
+      "Ada",
+    ),
+    /Failed to send resetPassword email via ZeptoMail: fetch failed/,
+  );
+});


### PR DESCRIPTION
## Summary
- Replace the ZeptoMail SDK usage in the auth mailer with a direct REST `fetch` call.
- Derive the REST API endpoint from the existing `SMTP_HOST=smtp.zeptomail.in` value, while also supporting explicit `ZEPTOMAIL_URL` / `ZEPTOMAIL_TOKEN` env vars.
- Add focused mailer tests for endpoint derivation and controlled transport errors.

## Why
The ECS task crash was caused by the ZeptoMail SDK throwing `TypeError: resp.json is not a function` after an auth email path attempted to send mail. The service itself recovered, but this made email-triggered requests capable of crashing the `quickvoice-server` container. Calling the ZeptoMail REST API directly gives us predictable error handling and avoids the SDK failure path.

## Production env note
No mandatory AWS production env change is required for this PR if `SMTP_HOST=smtp.zeptomail.in` and `SMTP_PASSWORD` is already the ZeptoMail Send Mail/API token. Optional cleanup later: add explicit `ZEPTOMAIL_URL=api.zeptomail.in` and/or `ZEPTOMAIL_TOKEN` for clarity.

## Validation
- `node --import tsx --test apps/server/tests/*.test.ts apps/server/tests/**/*.test.ts`