### PR TITLE
[codex] Fix inbound call log ingestion

### DIFF
--- a/apps/ai/handlers/calllog_handler.py
+++ b/apps/ai/handlers/calllog_handler.py
@@ -48,7 +48,7 @@ async def post_call_log(
     internal_api_key: str | None = None,
     post_json=None,
 ):
-    base_url = (server_api_url or os.getenv("SERVER_API_URL") or "").rstrip("/")
+    base_url = _api_base_url(server_api_url or os.getenv("SERVER_API_URL") or "")
     api_key = internal_api_key or os.getenv("INTERNAL_API_KEY")
     if not base_url:
         raise RuntimeError("SERVER_API_URL is required to post call logs")
@@ -65,6 +65,13 @@ async def post_call_log(
         headers["x-user-id"] = user_id
 
     return await (post_json or _post_json)(f"{base_url}/calls", headers, payload)
+
+
+def _api_base_url(server_api_url: str) -> str:
+    base_url = server_api_url.rstrip("/")
+    if not base_url:
+        return ""
+    return base_url if base_url.endswith("/api/v1") else f"{base_url}/api/v1"
 
 
 def _normalize_transcript_item(item: dict[str, Any], index: int) -> dict[str, str]:

--- a/apps/ai/tests/test_calllog_handler.py
+++ b/apps/ai/tests/test_calllog_handler.py
@@ -78,6 +78,24 @@ class CallLogHandlerTests(unittest.TestCase):
         self.assertEqual(headers["x-user-id"], "user_123")
         self.assertEqual(body["callId"], "room-123")
 
+    def test_post_call_log_appends_api_version_when_server_url_is_origin(self):
+        calls = []
+
+        async def fake_post_json(url, headers, body):
+            calls.append((url, headers, body))
+            return {"success": True, "data": {"callId": body["callId"]}}
+
+        asyncio.run(
+            post_call_log(
+                {"callId": "room-123", "organizationId": "org_123", "userId": "user_123"},
+                server_api_url="https://api.quickvoice.co",
+                internal_api_key="internal-secret",
+                post_json=fake_post_json,
+            )
+        )
+
+        self.assertEqual(calls[0][0], "https://api.quickvoice.co/api/v1/calls")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/apps/server/src/modules/agent/agent.repository.ts
+++ b/apps/server/src/modules/agent/agent.repository.ts
@@ -153,9 +153,14 @@ export const getAgentConfigByNumber= async (
     where: {
       number: phoneNumber,
     },
-    include: {
+    select: {
+      number: true,
+      organizationId: true,
+      userId: true,
+      provider: true,
       agent: {
-        include: {
+        select: {
+          userId: true,
           configuration: true,
           tools: true,
           mcpConnections: {
@@ -173,6 +178,10 @@ export const getAgentConfigByNumber= async (
 
   return {
     ...phone.agent.configuration,
+    organizationId: phone.organizationId,
+    userId: phone.userId ?? phone.agent.userId,
+    agentNumber: phone.number,
+    provider: phone.provider,
     tools: phone.agent.tools,
     mcpConnections: phone.agent.mcpConnections.map((item) => item.mcpConnection),
   };


### PR DESCRIPTION
## Summary
- Return `organizationId`, `userId`, `agentNumber`, and `provider` from the internal phone-number runtime config endpoint.
- Normalize call-log ingestion URLs so `SERVER_API_URL=https://api.quickvoice.co` posts to `/api/v1/calls`.
- Add a regression test for production-style call-log URL construction.

## Root cause
Inbound calls were connecting, but completed call logs were not being saved. Production AI logs showed:

`[CALL_LOG] Failed to post completed call: organization_id is required`

The worker fetched config by phone number and received the agent configuration, but the server response did not include tenant metadata from the linked phone/agent. Without `organizationId` and `userId`, the AI worker could not build a valid call-log payload for the internal `/calls` ingest route.

There was also a second issue on the same path: `post_call_log()` posted directly to `${SERVER_API_URL}/calls`. In production `SERVER_API_URL` is the origin (`https://api.quickvoice.co`), so the ingest URL needs `/api/v1/calls`.

## Validation
- `python3 apps/ai/tests/test_calllog_handler.py`
- `pnpm --filter server check-types`
- `pnpm --filter server build`

Full AI unittest discovery is still blocked locally by missing optional runtime deps (`loguru`, `livekit`), unrelated to this focused call-log handler test.
