### PR TITLE
Add call recording playback URLs

### DIFF
--- a/apps/console/src/components/calls/AudioPlayer.tsx
+++ b/apps/console/src/components/calls/AudioPlayer.tsx
@@ -1,8 +1,33 @@
 "use client";
 
-import { Music } from "lucide-react";
+import { useRef, useState } from "react";
+import { Download, Music, Pause, Play } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
 
 export function AudioPlayer({ src }: { src: string | null }) {
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const [playingSrc, setPlayingSrc] = useState<string | null>(null);
+    const playing = playingSrc === src;
+
+    async function togglePlayback() {
+        const audio = audioRef.current;
+        if (!audio) return;
+
+        if (playing) {
+            audio.pause();
+            setPlayingSrc(null);
+            return;
+        }
+
+        try {
+            await audio.play();
+            setPlayingSrc(src);
+        } catch {
+            setPlayingSrc(null);
+        }
+    }
+
     if (!src) {
         return (
             <div className="flex items-center gap-3 border bg-card p-4 text-sm text-muted-foreground">
@@ -13,12 +38,37 @@ export function AudioPlayer({ src }: { src: string | null }) {
     }
 
     return (
-        <div className="border bg-card p-4">
+        <div className="space-y-3 border bg-card p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3 text-sm font-medium">
+                    <Music className="size-4 text-muted-foreground" />
+                    <span>Recording</span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                    <Button
+                        type="button"
+                        size="sm"
+                        onClick={togglePlayback}
+                        aria-label={playing ? "Pause recording" : "Play recording"}
+                    >
+                        {playing ? <Pause /> : <Play />}
+                        {playing ? "Pause" : "Play recording"}
+                    </Button>
+                    <Button asChild type="button" variant="outline" size="sm">
+                        <a href={src} target="_blank" rel="noreferrer" download>
+                            <Download />
+                            Download
+                        </a>
+                    </Button>
+                </div>
+            </div>
             <audio
-                controls
+                ref={audioRef}
                 src={src}
                 preload="metadata"
-                className="w-full"
+                onEnded={() => setPlayingSrc(null)}
+                onPause={() => setPlayingSrc(null)}
+                onPlay={() => setPlayingSrc(src)}
             />
         </div>
     );

--- a/apps/server/src/modules/calllogs/calllog.service.ts
+++ b/apps/server/src/modules/calllogs/calllog.service.ts
@@ -1,10 +1,37 @@
 import { NotFoundError } from "../../common/errors/notFound.js";
+import { generateDownloadUrl } from "../../config/s3.js";
 import * as calllogRepository from "./calllog.repository.js";
 import type {
   IngestCallLogArgs,
   ListCallLogsArgs,
   ListTranscriptsArgs,
 } from "./calllog.schema.js";
+
+type RecordingSigner = (key: string) => Promise<string>;
+type CallWithRecording = { audioRecordingPath: string | null };
+
+const isHttpUrl = (value: string) => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const signCallRecordingUrl = async <T extends CallWithRecording>(
+  call: T,
+  signer: RecordingSigner = generateDownloadUrl
+): Promise<T> => {
+  if (!call.audioRecordingPath || isHttpUrl(call.audioRecordingPath)) {
+    return call;
+  }
+
+  return {
+    ...call,
+    audioRecordingPath: await signer(call.audioRecordingPath),
+  };
+};
 
 export const ingestCallLog = (args: IngestCallLogArgs) =>{
   return calllogRepository.saveCallLog(args);
@@ -17,7 +44,10 @@ export const listCallLogs = async (args: ListCallLogsArgs) => {
   const hasMore = rows.length > args.limit;
   const items = hasMore ? rows.slice(0, args.limit) : rows;
   const nextCursor = hasMore ? items[items.length - 1]!.callId : null;
-  return { items, nextCursor };
+  return {
+    items: await Promise.all(items.map((item) => signCallRecordingUrl(item))),
+    nextCursor,
+  };
 };
 
 export const getCallLog = async (organizationId: string, callId: string) => {
@@ -25,7 +55,7 @@ export const getCallLog = async (organizationId: string, callId: string) => {
   if (!row) {
     throw new NotFoundError("Call log not found");
   }
-  return row;
+  return signCallRecordingUrl(row);
 };
 
 export const getTranscripts = async (args: ListTranscriptsArgs) => {

--- a/apps/server/tests/calllogs/calllog.service.test.ts
+++ b/apps/server/tests/calllogs/calllog.service.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { signCallRecordingUrl } from "../../src/modules/calllogs/calllog.service.js";
+
+test("signCallRecordingUrl replaces a stored S3 key with a signed playback URL", async () => {
+  const call = {
+    callId: "SCL_recording123",
+    audioRecordingPath: "Voice-agents/Recordings/recording-123.ogg",
+  };
+
+  const signed = await signCallRecordingUrl(call, async (key) => {
+    return `https://recordings.quickvoice.test/${encodeURIComponent(key)}?signature=test`;
+  });
+
+  assert.equal(
+    signed.audioRecordingPath,
+    "https://recordings.quickvoice.test/Voice-agents%2FRecordings%2Frecording-123.ogg?signature=test"
+  );
+  assert.equal(call.audioRecordingPath, "Voice-agents/Recordings/recording-123.ogg");
+});
+
+test("signCallRecordingUrl leaves missing recordings and existing URLs unchanged", async () => {
+  const nullRecording = await signCallRecordingUrl(
+    { callId: "SCL_no_recording", audioRecordingPath: null },
+    async () => {
+      throw new Error("should not sign empty recording path");
+    }
+  );
+  assert.equal(nullRecording.audioRecordingPath, null);
+
+  const existingUrl = await signCallRecordingUrl(
+    {
+      callId: "SCL_url_recording",
+      audioRecordingPath: "https://cdn.quickvoice.test/recording.ogg",
+    },
+    async () => {
+      throw new Error("should not sign existing URL");
+    }
+  );
+  assert.equal(
+    existingUrl.audioRecordingPath,
+    "https://cdn.quickvoice.test/recording.ogg"
+  );
+});


### PR DESCRIPTION
## Summary
- Sign stored S3 recording keys before returning call logs to the console.
- Add a shared recording player with explicit Play/Pause and Download buttons.
- Cover the signing behavior with a focused server test.

## Why
LiveKit stores completed recordings as S3 object keys such as `Voice-agents/Recordings/<id>.ogg`. The console was passing that raw key into `<audio src>`, so even after recording upload works, the browser would not have a playable URL.

This change makes `GET /calls` and `GET /calls/:id` return a presigned playback URL for any stored S3 recording key. Existing null values and already-signed/absolute URLs are left unchanged.

## Validation
- `pnpm --filter server exec tsx --test tests/calllogs/calllog.service.test.ts`
- `pnpm --filter server check-types`
- `pnpm --filter server build`
- `pnpm --filter console exec eslint src/components/calls/AudioPlayer.tsx`
- `pnpm --filter console build`
- `git diff --check`

## Notes
- `pnpm --filter console lint` still fails on an unrelated existing error in `apps/console/src/hooks/queries/mcp.ts` (`prefer-const` for `intervalId`). The changed `AudioPlayer` file passes targeted lint.
- This depends on the Terraform recording-storage env PR adding `S3_BUCKET_NAME` to the server container.
