### PR TITLE
[codex] fix RAG retrieval during calls

### DIFF
--- a/apps/ai/main.py
+++ b/apps/ai/main.py
@@ -118,6 +118,48 @@ class Assistant(Agent):
         self._config = config
         self._call_context = call_context
 
+    def _rag_enabled(self) -> bool:
+        return bool(self._config.get("use_rag"))
+
+    def _agent_id(self) -> str:
+        return (
+            self._config.get("agent_id")
+            or self._call_context.get("agent_id")
+            or ""
+        )
+
+    async def on_user_turn_completed(self, turn_ctx, new_message) -> None:
+        if not self._rag_enabled():
+            return
+
+        agent_id = self._agent_id()
+        if not agent_id:
+            logger.warning("[rag] skipped retrieval because agent_id is missing")
+            return
+
+        query = new_message.text_content if hasattr(new_message, "text_content") else ""
+        if callable(query):
+            query = query()
+        query = str(query or "").strip()
+        if not query:
+            return
+
+        context = await get_rag_context(agent_id=agent_id, query=query)
+        if not context:
+            logger.info(f"[rag] no context returned for agent={agent_id}")
+            return
+
+        turn_ctx.add_message(
+            role="system",
+            content=(
+                "Relevant knowledge base context for the user's latest question. "
+                "Use this context to answer accurately. If it does not contain the answer, "
+                "say you do not have that information in the knowledge base.\n\n"
+                f"{context}"
+            ),
+        )
+        logger.info(f"[rag] injected context for agent={agent_id}")
+
     @function_tool
     async def search_knowledge_base(self, query: str, top_k: int = 5) -> str:
         """
@@ -127,10 +169,10 @@ class Assistant(Agent):
             query: The user question or the topic to search for.
             top_k: Maximum number of matching chunks to retrieve.
         """
-        if not self._config.get("use_rag"):
+        if not self._rag_enabled():
             return "Knowledge base search is disabled for this agent."
 
-        agent_id = self._call_context.get("agent_id") or self._config.get("agent_id")
+        agent_id = self._agent_id()
         if not agent_id:
             return "Knowledge base search is unavailable because this call has no agent_id."
 

--- a/apps/ai/tests/test_rag_runtime.py
+++ b/apps/ai/tests/test_rag_runtime.py
@@ -1,0 +1,80 @@
+import asyncio
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from livekit.agents import llm
+
+from main import Assistant
+
+
+def tool_names(agent: Assistant) -> list[str]:
+    return [tool._info.name for tool in agent.tools]
+
+
+class RagRuntimeTests(unittest.TestCase):
+    def test_assistant_exposes_knowledge_base_search_tool(self):
+        agent = Assistant(
+            "You are helpful.",
+            {"use_rag": True, "agent_id": "agent_123"},
+            {"agent_id": "agent_123"},
+        )
+
+        self.assertIn("search_knowledge_base", tool_names(agent))
+
+    def test_rag_context_is_injected_after_user_turn_when_enabled(self):
+        async def fake_get_rag_context(agent_id: str, query: str, top_k: int = 5) -> str:
+            self.assertEqual(agent_id, "agent_123")
+            self.assertEqual(query, "What is the refund policy?")
+            return "[refund-policy]\nRefunds are available within 30 days."
+
+        async def run():
+            agent = Assistant(
+                "You are helpful.",
+                {"use_rag": True, "agent_id": "agent_123"},
+                {"agent_id": "agent_123"},
+            )
+            turn_ctx = llm.ChatContext.empty()
+            message = turn_ctx.add_message(
+                role="user",
+                content="What is the refund policy?",
+            )
+
+            with patch("main.get_rag_context", fake_get_rag_context):
+                await agent.on_user_turn_completed(turn_ctx, message)
+
+            return turn_ctx.messages()
+
+        messages = asyncio.run(run())
+        self.assertEqual(messages[-1].role, "system")
+        self.assertIn("Relevant knowledge base context", messages[-1].text_content)
+        self.assertIn("Refunds are available within 30 days", messages[-1].text_content)
+
+    def test_rag_context_is_not_injected_when_disabled(self):
+        async def fake_get_rag_context(*_args, **_kwargs) -> str:
+            raise AssertionError("RAG should not be queried")
+
+        async def run():
+            agent = Assistant(
+                "You are helpful.",
+                {"use_rag": False, "agent_id": "agent_123"},
+                {"agent_id": "agent_123"},
+            )
+            turn_ctx = llm.ChatContext.empty()
+            message = turn_ctx.add_message(role="user", content="What is covered?")
+
+            with patch("main.get_rag_context", fake_get_rag_context):
+                await agent.on_user_turn_completed(turn_ctx, message)
+
+            return turn_ctx.messages()
+
+        messages = asyncio.run(run())
+        self.assertEqual(len(messages), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/server/src/modules/kb/kb-processing-result.ts
+++ b/apps/server/src/modules/kb/kb-processing-result.ts
@@ -1,0 +1,43 @@
+type KbProcessingItem = {
+  kbId?: unknown;
+  status?: unknown;
+  error?: unknown;
+};
+
+type KbProcessingResponse = {
+  success?: unknown;
+  processed?: unknown;
+};
+
+export function assertKbProcessingSucceeded(
+  body: KbProcessingResponse,
+  expectedKbIds: string[]
+) {
+  if (body?.success !== true || !Array.isArray(body.processed)) {
+    throw new Error("KB processing returned an invalid response body");
+  }
+
+  const processed = body.processed as KbProcessingItem[];
+  const failures = processed.filter((item) => item.status !== "ok");
+  const processedIds = new Set(
+    processed
+      .map((item) => (typeof item.kbId === "string" ? item.kbId : null))
+      .filter((kbId): kbId is string => kbId !== null)
+  );
+  const missingIds = expectedKbIds.filter((kbId) => !processedIds.has(kbId));
+
+  if (failures.length > 0 || missingIds.length > 0) {
+    const failureSummary = failures
+      .map((item) => {
+        const kbId = typeof item.kbId === "string" ? item.kbId : "unknown";
+        const error = typeof item.error === "string" ? item.error : "unknown error";
+        return `${kbId}: ${error}`;
+      })
+      .join("; ");
+    const missingSummary = missingIds.length
+      ? `missing results for ${missingIds.join(", ")}`
+      : "";
+    const details = [failureSummary, missingSummary].filter(Boolean).join("; ");
+    throw new Error(`KB processing failed: ${details}`);
+  }
+}

--- a/apps/server/src/workers/kb.worker.ts
+++ b/apps/server/src/workers/kb.worker.ts
@@ -1,6 +1,7 @@
 import { Worker } from "bullmq";
 import { redisConnection } from "../config/redis.js";
 import { generateDownloadUrl } from "../config/s3.js";
+import { assertKbProcessingSucceeded } from "../modules/kb/kb-processing-result.js";
 import * as kbRepository from "../modules/kb/kb.repository.js";
 import type { KbJobData, KbJobName } from "../queues/kb.queue.js";
 
@@ -34,6 +35,9 @@ export const kbWorker = new Worker<KbJobData, void, KbJobName>(
       const body = await res.text().catch(() => "");
       throw new Error(`KB processing failed (${res.status}): ${body}`);
     }
+
+    const body = await res.json();
+    assertKbProcessingSucceeded(body, kbIds);
 
     // 3. Mark all sources as ACTIVE
     await kbRepository.markActive(kbIds, agentId);

--- a/apps/server/tests/kb/kb-processing-result.test.ts
+++ b/apps/server/tests/kb/kb-processing-result.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { assertKbProcessingSucceeded } from "../../src/modules/kb/kb-processing-result.js";
+
+test("assertKbProcessingSucceeded accepts successful per-document results", () => {
+  assert.doesNotThrow(() =>
+    assertKbProcessingSucceeded(
+      {
+        success: true,
+        processed: [
+          { kbId: "kb_1", status: "ok" },
+          { kbId: "kb_2", status: "ok" },
+        ],
+      },
+      ["kb_1", "kb_2"]
+    )
+  );
+});
+
+test("assertKbProcessingSucceeded rejects per-document failures in a 200 response", () => {
+  assert.throws(
+    () =>
+      assertKbProcessingSucceeded(
+        {
+          success: true,
+          processed: [
+            { kbId: "kb_1", status: "ok" },
+            { kbId: "kb_2", status: "error", error: "PINECONE_API_KEY missing" },
+          ],
+        },
+        ["kb_1", "kb_2"]
+      ),
+    /KB processing failed: kb_2: PINECONE_API_KEY missing/
+  );
+});
+
+test("assertKbProcessingSucceeded rejects missing document results", () => {
+  assert.throws(
+    () =>
+      assertKbProcessingSucceeded(
+        {
+          success: true,
+          processed: [{ kbId: "kb_1", status: "ok" }],
+        },
+        ["kb_1", "kb_2"]
+      ),
+    /missing results for kb_2/
+  );
+});


### PR DESCRIPTION
## Summary
- inject knowledge-base context into live AI calls when RAG is enabled
- keep the knowledge-base search tool available with current main behavior
- make the server KB worker reject per-document indexing failures before marking documents ACTIVE

## Root cause
Documents could show ACTIVE because the AI KB endpoint returned HTTP 200 even when individual document processing failed. The live call agent also had a KB search tool, but no automatic runtime retrieval/injection for user turns.

## Validation
- apps/ai/.venv/bin/python -m unittest discover -s apps/ai/tests
- pnpm --dir apps/server exec tsc --noEmit
- pnpm --dir apps/server exec tsx --test tests/**/*.test.ts