### PR TITLE
[codex] fix QuickVoice signup emails over SMTP

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,6 +35,7 @@
     "inngest": "^4.2.4",
     "livekit-server-sdk": "^2.15.1",
     "morgan": "^1.10.1",
+    "nodemailer": "^9.0.1",
     "prisma": "^7.5.0",
     "stripe": "^19.1.0",
     "swagger-ui-express": "^5.0.1",
@@ -50,6 +51,7 @@
     "@types/express": "^5.0.0",
     "@types/morgan": "^1.9.10",
     "@types/node": "^20",
+    "@types/nodemailer": "^8.0.1",
     "@types/swagger-ui-express": "^4.1.8",
     "tsx": "^4.20.0",
     "typescript": "^5"

--- a/apps/server/src/lib/mailer.ts
+++ b/apps/server/src/lib/mailer.ts
@@ -1,3 +1,5 @@
+import nodemailer from "nodemailer";
+
 type AuthEmailType = "verifyEmail" | "resetPassword";
 
 interface EmailContent {
@@ -16,22 +18,19 @@ function requireEnv(name: string) {
 }
 
 function getZeptoMailToken() {
-  const token = process.env.ZEPTOMAIL_TOKEN || process.env.SMTP_PASSWORD;
+  const token = process.env.ZEPTOMAIL_TOKEN;
   if (!token) {
-    throw new Error(
-      "Missing required email environment variable: ZEPTOMAIL_TOKEN or SMTP_PASSWORD",
-    );
+    throw new Error("Missing required email environment variable: ZEPTOMAIL_TOKEN");
   }
-  return token;
+  const trimmedToken = token.trim();
+  if (/^zoho-enczapikey\s+/i.test(trimmedToken)) {
+    return trimmedToken;
+  }
+  return `zoho-enczapikey ${trimmedToken}`;
 }
 
 function getZeptoMailEndpoint() {
-  const rawUrl = process.env.ZEPTOMAIL_URL || process.env.SMTP_HOST;
-  if (!rawUrl) {
-    throw new Error(
-      "Missing required email environment variable: ZEPTOMAIL_URL or SMTP_HOST",
-    );
-  }
+  const rawUrl = process.env.ZEPTOMAIL_URL || process.env.SMTP_HOST || "api.zeptomail.com";
 
   const urlWithProtocol = /^https?:\/\//i.test(rawUrl)
     ? rawUrl
@@ -55,6 +54,28 @@ function getZeptoMailEndpoint() {
   endpoint.hash = "";
 
   return endpoint.toString();
+}
+
+function getSmtpPort() {
+  const rawPort = process.env.SMTP_PORT || "587";
+  const port = Number.parseInt(rawPort, 10);
+  if (!Number.isFinite(port)) {
+    throw new Error("Invalid email environment variable: SMTP_PORT");
+  }
+  return port;
+}
+
+function getSmtpTransport() {
+  const port = getSmtpPort();
+  return nodemailer.createTransport({
+    host: requireEnv("SMTP_HOST"),
+    port,
+    secure: port === 465,
+    auth: {
+      user: requireEnv("SMTP_USERNAME"),
+      pass: requireEnv("SMTP_PASSWORD"),
+    },
+  });
 }
 
 function escapeHtml(value: string) {
@@ -134,6 +155,8 @@ export async function sendEmail(
   const content = contentFor(type);
   const fromEmail = requireEnv("FROM_EMAIL");
   const fromName = "Console|Quickvoice";
+  const text = buildText(content, url, fullName);
+  const html = buildHtml(content, url, fullName);
 
   const payload = {
     from: {
@@ -149,28 +172,52 @@ export async function sendEmail(
       },
     ],
     subject: content.subject,
-    textbody: buildText(content, url, fullName),
-    htmlbody: buildHtml(content, url, fullName),
+    textbody: text,
+    htmlbody: html,
   };
 
-  try {
-    const response = await fetch(getZeptoMailEndpoint(), {
-      method: "POST",
-      headers: {
-        Authorization: getZeptoMailToken(),
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    });
-    const body = await response.text();
+  if (process.env.ZEPTOMAIL_TOKEN) {
+    try {
+      const response = await fetch(getZeptoMailEndpoint(), {
+        method: "POST",
+        headers: {
+          Authorization: getZeptoMailToken(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+      const body = await response.text();
 
-    if (!response.ok) {
-      throw new Error(
-        `ZeptoMail responded with ${response.status} ${response.statusText}: ${body}`,
-      );
+      if (!response.ok) {
+        throw new Error(
+          `ZeptoMail responded with ${response.status} ${response.statusText}: ${body}`,
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to send ${type} email via ZeptoMail: ${message}`);
     }
+    return;
+  }
+
+  try {
+    await getSmtpTransport().sendMail({
+      from: {
+        address: fromEmail,
+        name: fromName,
+      },
+      to: [
+        {
+          address: email,
+          name: fullName,
+        },
+      ],
+      subject: content.subject,
+      text,
+      html,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to send ${type} email via ZeptoMail: ${message}`);
+    throw new Error(`Failed to send ${type} email via SMTP: ${message}`);
   }
 }

--- a/apps/server/tests/mailer.test.ts
+++ b/apps/server/tests/mailer.test.ts
@@ -1,24 +1,101 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
+import nodemailer from "nodemailer";
 
 import { sendEmail } from "../src/lib/mailer.js";
 
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
+const originalCreateTransport = nodemailer.createTransport;
 
 afterEach(() => {
   process.env = { ...originalEnv };
   globalThis.fetch = originalFetch;
+  nodemailer.createTransport = originalCreateTransport;
 });
 
-function setEmailEnv() {
+function setSmtpEmailEnv() {
   process.env.SMTP_HOST = "smtp.zeptomail.in";
+  process.env.SMTP_PORT = "587";
+  process.env.SMTP_USERNAME = "emailapikey";
   process.env.SMTP_PASSWORD = "test-token";
   process.env.FROM_EMAIL = "no-reply@mail.quickvoice.co";
+  delete process.env.ZEPTOMAIL_TOKEN;
+  delete process.env.ZEPTOMAIL_URL;
 }
 
+function setApiEmailEnv() {
+  process.env.ZEPTOMAIL_URL = "smtp.zeptomail.in";
+  process.env.ZEPTOMAIL_TOKEN = "test-token";
+  process.env.FROM_EMAIL = "no-reply@mail.quickvoice.co";
+  delete process.env.SMTP_HOST;
+  delete process.env.SMTP_PORT;
+  delete process.env.SMTP_USERNAME;
+  delete process.env.SMTP_PASSWORD;
+}
+
+test("sendEmail uses SMTP when only SMTP credentials are configured", async () => {
+  setSmtpEmailEnv();
+
+  const transports: unknown[] = [];
+  const messages: unknown[] = [];
+  nodemailer.createTransport = ((options: unknown) => {
+    transports.push(options);
+    return {
+      sendMail: async (message: unknown) => {
+        messages.push(message);
+        return { messageId: "smtp-test" };
+      },
+    };
+  }) as typeof nodemailer.createTransport;
+  globalThis.fetch = (async () => {
+    throw new Error("fetch should not be called for SMTP credentials");
+  }) as typeof fetch;
+
+  await sendEmail(
+    "verifyEmail",
+    "ada@example.com",
+    "https://console.quickvoice.co/verify",
+    "Ada",
+  );
+
+  assert.deepEqual(transports[0], {
+    host: "smtp.zeptomail.in",
+    port: 587,
+    secure: false,
+    auth: {
+      user: "emailapikey",
+      pass: "test-token",
+    },
+  });
+  const message = messages[0] as {
+    from: { address: string; name: string };
+    to: Array<{ address: string; name: string }>;
+    subject: string;
+    text: string;
+    html: string;
+  };
+  assert.deepEqual(message.from, {
+    address: "no-reply@mail.quickvoice.co",
+    name: "Console|Quickvoice",
+  });
+  assert.deepEqual(message.to, [{ address: "ada@example.com", name: "Ada" }]);
+  assert.equal(message.subject, "Verify your QuickVoice email");
+  assert.equal(
+    message.text,
+    [
+      "Hi Ada,",
+      "",
+      "Confirm your email address to finish setting up your QuickVoice account.",
+      "",
+      "Verify email: https://console.quickvoice.co/verify",
+    ].join("\n"),
+  );
+  assert.match(message.html, /Verify your email/);
+});
+
 test("sendEmail derives the ZeptoMail API endpoint from the SMTP host", async () => {
-  setEmailEnv();
+  setApiEmailEnv();
 
   const calls: Array<{ url: string; init?: RequestInit }> = [];
   globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
@@ -40,14 +117,17 @@ test("sendEmail derives the ZeptoMail API endpoint from the SMTP host", async ()
   assert.equal(calls[0].url, "https://api.zeptomail.in/v1.1/email");
   assert.equal(calls[0].init?.method, "POST");
   const headers = calls[0].init?.headers as Record<string, string>;
-  assert.equal(headers.Authorization, "test-token");
+  assert.equal(headers.Authorization, "zoho-enczapikey test-token");
 });
 
-test("sendEmail rejects with a controlled error when ZeptoMail transport fails", async () => {
-  setEmailEnv();
-  globalThis.fetch = (async () => {
-    throw new TypeError("fetch failed");
-  }) as typeof fetch;
+test("sendEmail rejects with a controlled error when SMTP transport fails", async () => {
+  setSmtpEmailEnv();
+  nodemailer.createTransport = (() =>
+    ({
+      sendMail: async () => {
+        throw new Error("SMTP down");
+      },
+    }) as ReturnType<typeof nodemailer.createTransport>) as typeof nodemailer.createTransport;
 
   await assert.rejects(
     sendEmail(
@@ -56,6 +136,6 @@ test("sendEmail rejects with a controlled error when ZeptoMail transport fails",
       "https://console.quickvoice.co/reset",
       "Ada",
     ),
-    /Failed to send resetPassword email via ZeptoMail: fetch failed/,
+    /Failed to send resetPassword email via SMTP: SMTP down/,
   );
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       morgan:
         specifier: ^1.10.1
         version: 1.10.1
+      nodemailer:
+        specifier: ^9.0.1
+        version: 9.0.1
       prisma:
         specifier: ^7.5.0
         version: 7.7.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.2)
@@ -230,6 +233,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.37
+      '@types/nodemailer':
+        specifier: ^8.0.1
+        version: 8.0.1
       '@types/swagger-ui-express':
         specifier: ^4.1.8
         version: 4.1.8
@@ -3439,6 +3445,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
+
   '@types/oracledb@6.5.2':
     resolution: {integrity: sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==}
 
@@ -5881,6 +5890,10 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
+    engines: {node: '>=6.0.0'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -10837,6 +10850,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/nodemailer@8.0.1':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -13589,6 +13606,8 @@ snapshots:
     optional: true
 
   node-releases@2.0.36: {}
+
+  nodemailer@9.0.1: {}
 
   npm-run-path@4.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- send signup/reset auth emails through the configured SMTP transport when only SMTP credentials are present
- keep ZeptoMail REST API support for deployments that provide a dedicated ZEPTOMAIL_TOKEN
- add mailer regression tests for SMTP routing, API token normalization, and SMTP failure errors

## Root cause
Production has valid ZeptoMail SMTP credentials in ECS/Secrets Manager, and SMTP login succeeds. The server mailer was treating SMTP_PASSWORD as a ZeptoMail REST API send-mail token, so signup verification emails failed in Better Auth background tasks with 401 Invalid API Token found.

## Validation
- pnpm --dir apps/server install --frozen-lockfile --offline
- pnpm --dir apps/server exec tsc --noEmit
- pnpm --dir apps/server exec tsx --test tests/**/*.test.ts
- git diff --check -- apps/server/src/lib/mailer.ts apps/server/tests/mailer.test.ts apps/server/package.json pnpm-lock.yaml
- live SMTP smoke send through patched mailer to rahul.yeindia@gmail.com returned smtp_send=ok