### PR TITLE
[codex] remove package managers from server runtime image

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -43,6 +43,18 @@ COPY apps/server/package.json apps/server/package.json
 COPY packages/typescript-config packages/typescript-config
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm install --frozen-lockfile --prod --filter server...
+RUN rm -rf \
+    /pnpm \
+    /root/.cache/node \
+    /usr/local/bin/corepack \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/bin/pnpm \
+    /usr/local/bin/pnpx \
+    /usr/local/bin/yarn \
+    /usr/local/bin/yarnpkg \
+    /usr/local/lib/node_modules/corepack \
+    /usr/local/lib/node_modules/npm
 
 WORKDIR /app/apps/server
 COPY --from=build --chown=server:nodejs /app/apps/server/dist ./dist

--- a/tests/root-tooling-ci.test.mjs
+++ b/tests/root-tooling-ci.test.mjs
@@ -81,6 +81,9 @@ test("server runtime image installs only production server dependencies", async 
   assert.doesNotMatch(dockerfile, /pnpm .*deploy/);
   assert.match(dockerfile, /apt-get upgrade -y/);
   assert.match(dockerfile, /COPY packages\/typescript-config packages\/typescript-config/);
+  assert.match(dockerfile, /rm -rf[\s\S]*\/root\/\.cache\/node/);
+  assert.match(dockerfile, /rm -rf[\s\S]*\/usr\/local\/lib\/node_modules\/npm/);
+  assert.match(dockerfile, /rm -rf[\s\S]*\/usr\/local\/lib\/node_modules\/corepack/);
   assert.doesNotMatch(dockerfile, /COPY packages\/typescript-config\/package\.json/);
   assert.doesNotMatch(
     dockerfile,


### PR DESCRIPTION
## Summary
- remove pnpm/corepack cache and bundled npm from the final server runtime image after production dependency install
- add a regression check so the runtime Dockerfile continues cleaning package-manager toolchains

## Why
The post-merge `Server Build and Deploy` run for PR #35 still failed at Trivy because the final image contained vulnerable packages from `/root/.cache/node/corepack/v1/pnpm/9.0.0` and `/usr/local/lib/node_modules/npm`, not from the app runtime dependencies.

## Verification
- node --test tests/root-tooling-ci.test.mjs
- git diff --check
