### PR TITLE
[codex] fix console dashboard audit UX issues

### DIFF
--- a/apps/ai/Dockerfile
+++ b/apps/ai/Dockerfile
@@ -46,9 +46,13 @@ WORKDIR /app
 # Copy just the dependency files first, for more efficient layer caching
 COPY requirements.txt ./
 
-# Install Python dependencies using pip
-# --no-cache-dir ensures we don't use the system cache
-RUN pip install --no-cache-dir -r requirements.txt
+# CI can validate the image with a CPU-only Torch wheel to avoid pulling CUDA
+# wheels that exceed the hosted runner's disk budget.
+ARG PREINSTALL_CPU_TORCH=false
+RUN if [ "$PREINSTALL_CPU_TORCH" = "true" ]; then \
+      pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu; \
+    fi \
+  && pip install --no-cache-dir -r requirements.txt
 
 # Copy all remaining pplication files into the container
 # This includes source code, configuration files, and dependency specifications

--- a/apps/console/src/app/(app)/dashboard/loading.tsx
+++ b/apps/console/src/app/(app)/dashboard/loading.tsx
@@ -1,5 +1,5 @@
-import { PageSkeleton } from "@/src/components/common/skeletons";
+import { DashboardLoadingSkeleton } from "@/src/components/common/skeletons";
 
 export default function Loading() {
-  return <PageSkeleton />;
+  return <DashboardLoadingSkeleton />;
 }

--- a/apps/console/src/app/(app)/dashboard/page.tsx
+++ b/apps/console/src/app/(app)/dashboard/page.tsx
@@ -1,98 +1,262 @@
 "use client";
 
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { AlertCircle, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { AlertTriangle } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
-import { EmptyState } from "@/src/components/common/EmptyState";
+import {
+  ErrorState,
+  OfflineState,
+  PermissionState,
+} from "@/src/components/common/EmptyState";
 import { PageHeader } from "@/src/components/common/PageHeader";
+import { RetryButton } from "@/src/components/common/RetryButton";
 import { RangeSwitcher } from "@/src/components/dashboard/RangeSwitcher";
 import { KpiCards } from "@/src/components/dashboard/KpiCards";
 import { VolumeChart } from "@/src/components/dashboard/VolumeChart";
 import { BreakdownCharts } from "@/src/components/dashboard/BreakdownCharts";
 import { RecentCallsTable } from "@/src/components/dashboard/RecentCallsTable";
 import { AgentActivityList } from "@/src/components/dashboard/AgentActivityList";
+import { DashboardFreshness } from "@/src/components/dashboard/DashboardFreshness";
 import { useDashboardSummary } from "@/src/hooks/queries/dashboard";
-import type { DashboardRange } from "@/src/lib/api/resources/dashboard";
+import type {
+  DashboardRange,
+  DashboardSummary,
+} from "@/src/lib/api/resources/dashboard";
+import {
+  apiErrorStatus,
+  getApiErrorStateCopy,
+} from "@/src/lib/api-error-state";
+
+const MISSING_SECTION_FORMAT = new Intl.ListFormat("en-US", {
+  style: "long",
+  type: "conjunction",
+});
 
 function resolveRange(param: string | null): DashboardRange {
   if (param === "24h" || param === "7d" || param === "30d") return param;
   return "7d";
 }
 
+function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(true);
+
+  useEffect(() => {
+    function syncOnlineState() {
+      setIsOnline(navigator.onLine);
+    }
+
+    syncOnlineState();
+    window.addEventListener("online", syncOnlineState);
+    window.addEventListener("offline", syncOnlineState);
+
+    return () => {
+      window.removeEventListener("online", syncOnlineState);
+      window.removeEventListener("offline", syncOnlineState);
+    };
+  }, []);
+
+  return isOnline;
+}
+
+function collectionSize(value: unknown) {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function isPermissionError(error: unknown) {
+  const status = apiErrorStatus(error);
+  return status === 401 || status === 403;
+}
+
+function getMissingDashboardSections(summary?: DashboardSummary) {
+  if (!summary || (summary.totals?.calls ?? 0) === 0) return [];
+
+  const missingSections: string[] = [];
+  if (collectionSize(summary.series) === 0) missingSections.push("traffic timeline");
+  if (collectionSize(summary.statusBreakdown) === 0) {
+    missingSections.push("outcome breakdown");
+  }
+  if (collectionSize(summary.directionBreakdown) === 0) {
+    missingSections.push("routing mix");
+  }
+  if (collectionSize(summary.topAgents) === 0) missingSections.push("agent activity");
+  if (collectionSize(summary.recent) === 0) missingSections.push("recent calls");
+  return missingSections;
+}
+
+function DashboardPartialDataNotice({ sections }: { sections: string[] }) {
+  if (!sections.length) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col gap-3 border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-800 dark:text-amber-200 sm:flex-row sm:items-start sm:justify-between"
+    >
+      <div className="flex gap-3">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        <div>
+          <p className="font-semibold">Partial dashboard data</p>
+          <p className="mt-1">
+            The summary loaded, but {MISSING_SECTION_FORMAT.format(sections)}{" "}
+            {sections.length === 1 ? "is" : "are"} not available yet. Refresh or
+            review call logs while the remaining data catches up.
+          </p>
+        </div>
+      </div>
+      <Button asChild variant="outline" size="sm" className="shrink-0 bg-card">
+        <Link href="/calls">Review call logs</Link>
+      </Button>
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const params = useSearchParams();
   const range = resolveRange(params.get("range"));
-  const { data, isLoading, isError, isFetching, refetch } = useDashboardSummary(range);
+  const isOnline = useOnlineStatus();
+  const {
+    data,
+    dataUpdatedAt,
+    error,
+    isLoading,
+    isError,
+    isFetching,
+    isStale,
+    refetch,
+  } = useDashboardSummary(range);
   const successPct = Math.round((data?.totals.successRate ?? 0) * 100);
   const exceptionCalls =
     (data?.totals.failedCalls ?? 0) + (data?.totals.missedCalls ?? 0);
+  const showBlockingError = isError && !data;
+  const dashboardHasPermissionError =
+    showBlockingError && isPermissionError(error);
+  const dashboardErrorState = showBlockingError
+    ? getApiErrorStateCopy(error, {
+        resourceName: "dashboard",
+        isOnline,
+        overrides: {
+          forbidden: {
+            title: "Dashboard access required",
+            description:
+              "You need dashboard and call reporting permission to view this operations summary. Ask a workspace owner to update your role.",
+          },
+        },
+      })
+    : null;
+  const missingDashboardSections = getMissingDashboardSections(data);
+  const dashboardRetryAction = (
+    <RetryButton
+      onClick={() => refetch()}
+      isRetrying={isFetching}
+      disabled={
+        dashboardErrorState?.kind === "offline" && !isOnline
+      }
+    >
+      Retry
+    </RetryButton>
+  );
+  const dashboardErrorAction =
+    dashboardErrorState?.reason === "forbidden" ? (
+      <Button asChild variant="outline">
+        <Link href="/settings/roles">Review role settings</Link>
+      </Button>
+    ) : dashboardErrorState?.reason === "unauthorized" ? (
+      <Button asChild variant="outline">
+        <Link href="/login">Sign in</Link>
+      </Button>
+    ) : (
+      dashboardRetryAction
+    );
 
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
         title="Dashboard"
         description="A compact view of call volume, outcomes, routing, and agent performance."
-        actions={<RangeSwitcher current={range} />}
+        actions={<RangeSwitcher current={range} loading={isFetching} />}
       />
-      {isError ? (
-        <EmptyState
-          icon={AlertCircle}
-          title="Could not load dashboard"
-          description="Refresh the summary or try again after checking your connection."
-          action={
-            <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
-              <RefreshCw className={isFetching ? "animate-spin" : undefined} />
-              Retry
-            </Button>
-          }
+      <DashboardFreshness
+        summary={data}
+        loading={isLoading}
+        dataUpdatedAt={dataUpdatedAt}
+        isFetching={isFetching}
+        isStale={isStale}
+        onRefresh={() => refetch()}
+      />
+      {dashboardErrorState?.kind === "offline" ? (
+        <OfflineState
+          title={dashboardErrorState.title}
+          description={dashboardErrorState.description}
+          action={dashboardErrorAction}
+        />
+      ) : dashboardErrorState?.kind === "permission" ||
+        dashboardHasPermissionError ? (
+        <PermissionState
+          title={dashboardErrorState?.title}
+          description={dashboardErrorState?.description}
+          action={dashboardErrorAction}
+        />
+      ) : dashboardErrorState ? (
+        <ErrorState
+          title={dashboardErrorState.title}
+          description={dashboardErrorState.description}
+          action={dashboardErrorAction}
         />
       ) : (
-      <>
-      <div className="grid gap-4 border bg-card p-5 lg:grid-cols-[1fr_340px] lg:items-center">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Operations snapshot
-          </p>
-          <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground">
-            {isLoading
-              ? "Loading call performance"
-              : `${data?.totals.calls ?? 0} calls at ${successPct}% success`}
-          </h2>
-          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-            Monitor traffic shape, service quality, and agent load from one place.
-          </p>
-        </div>
-        <div className="grid grid-cols-3 border bg-background text-center text-xs">
-          <div className="border-r px-3 py-3">
-            <p className="text-lg font-semibold text-foreground">
-              {data?.totals.minutes ?? 0}
-            </p>
-            <p className="text-muted-foreground">minutes</p>
+        <>
+          <DashboardPartialDataNotice sections={missingDashboardSections} />
+          <div className="grid gap-4 border bg-card p-5 lg:grid-cols-[1fr_340px] lg:items-center">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Operations snapshot
+              </p>
+              <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground">
+                {isLoading
+                  ? "Loading call performance"
+                  : `${data?.totals.calls ?? 0} calls at ${successPct}% success`}
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                Monitor traffic shape, service quality, and agent load from one
+                place.
+              </p>
+            </div>
+            <div className="grid grid-cols-3 border bg-background text-center text-xs">
+              <div className="border-r px-3 py-3">
+                <p className="text-lg font-semibold text-foreground">
+                  {data?.totals.minutes ?? 0}
+                </p>
+                <p className="text-muted-foreground">minutes</p>
+              </div>
+              <div className="border-r px-3 py-3">
+                <p className="text-lg font-semibold text-foreground">
+                  {exceptionCalls}
+                </p>
+                <p className="text-muted-foreground">exceptions</p>
+              </div>
+              <div className="px-3 py-3">
+                <p className="text-lg font-semibold text-foreground">
+                  {data?.topAgents.length ?? 0}
+                </p>
+                <p className="text-muted-foreground">agents</p>
+              </div>
+            </div>
           </div>
-          <div className="border-r px-3 py-3">
-            <p className="text-lg font-semibold text-foreground">
-              {exceptionCalls}
-            </p>
-            <p className="text-muted-foreground">exceptions</p>
+          <KpiCards summary={data} range={range} loading={isLoading} />
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+            <div className="xl:col-span-2">
+              <VolumeChart summary={data} range={range} loading={isLoading} />
+            </div>
+            <AgentActivityList
+              summary={data}
+              range={range}
+              loading={isLoading}
+            />
           </div>
-          <div className="px-3 py-3">
-            <p className="text-lg font-semibold text-foreground">
-              {data?.topAgents.length ?? 0}
-            </p>
-            <p className="text-muted-foreground">agents</p>
-          </div>
-        </div>
-      </div>
-      <KpiCards summary={data} loading={isLoading} />
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
-        <div className="xl:col-span-2">
-          <VolumeChart summary={data} range={range} loading={isLoading} />
-        </div>
-        <AgentActivityList summary={data} loading={isLoading} />
-      </div>
-      <BreakdownCharts summary={data} loading={isLoading} />
-      <RecentCallsTable summary={data} loading={isLoading} />
-      </>
+          <BreakdownCharts summary={data} range={range} loading={isLoading} />
+          <RecentCallsTable summary={data} loading={isLoading} />
+        </>
       )}
     </div>
   );

--- a/apps/console/src/components/common/EmptyState.tsx
+++ b/apps/console/src/components/common/EmptyState.tsx
@@ -1,37 +1,264 @@
-import type { LucideIcon } from "lucide-react";
+import {
+  AlertTriangle,
+  CircleAlert,
+  Inbox,
+  Loader2,
+  ShieldAlert,
+  WifiOff,
+  type LucideIcon,
+} from "lucide-react";
 import type { ReactNode } from "react";
+
+import {
+  getApiErrorStateCopy,
+  type ApiErrorStateCopyOptions,
+} from "@/src/lib/api-error-state";
 import { cn } from "@/src/lib/utils";
 
+export type EmptyStateVariant =
+  | "empty"
+  | "error"
+  | "permission"
+  | "offline"
+  | "warning";
+export type StateKind = EmptyStateVariant | "loading";
+
+type StateRole = "status" | "alert";
+type StateLive = "polite" | "assertive";
+
+type StateViewDefinition = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  role: StateRole;
+  live: StateLive;
+  surfaceClassName: string;
+  iconClassName: string;
+  iconWrapperClassName: string;
+};
+
+const STATE_VIEW_COPY = {
+  empty: {
+    icon: Inbox,
+    title: "Nothing here yet",
+    description: "When data is available, it will appear here.",
+    role: "status",
+    live: "polite",
+    surfaceClassName: "border-border bg-card",
+    iconClassName: "text-muted-foreground",
+    iconWrapperClassName: "bg-muted text-muted-foreground",
+  },
+  loading: {
+    icon: Loader2,
+    title: "Loading",
+    description: "Fetching the latest workspace data.",
+    role: "status",
+    live: "polite",
+    surfaceClassName: "border-border bg-card/40",
+    iconClassName: "animate-spin text-primary motion-reduce:animate-none",
+    iconWrapperClassName: "bg-primary/10 text-primary",
+  },
+  error: {
+    icon: AlertTriangle,
+    title: "Something went wrong",
+    description: "Refresh the page or try again in a moment.",
+    role: "alert",
+    live: "assertive",
+    surfaceClassName: "border-destructive/30 bg-destructive/5",
+    iconClassName: "text-destructive",
+    iconWrapperClassName: "bg-destructive/10 text-destructive",
+  },
+  permission: {
+    icon: ShieldAlert,
+    title: "Access required",
+    description: "Ask a workspace admin for access to this area.",
+    role: "alert",
+    live: "assertive",
+    surfaceClassName: "border-primary/30 bg-primary/5",
+    iconClassName: "text-primary",
+    iconWrapperClassName: "bg-primary/10 text-primary",
+  },
+  offline: {
+    icon: WifiOff,
+    title: "You are offline",
+    description: "Reconnect to the internet to continue working in QuickVoice.",
+    role: "alert",
+    live: "assertive",
+    surfaceClassName: "border-muted-foreground/30 bg-muted/40",
+    iconClassName: "text-muted-foreground",
+    iconWrapperClassName: "bg-muted text-muted-foreground",
+  },
+  warning: {
+    icon: CircleAlert,
+    title: "Review before continuing",
+    description: "Check this workspace state before taking the next step.",
+    role: "alert",
+    live: "assertive",
+    surfaceClassName: "border-warning/30 bg-warning/10",
+    iconClassName: "text-warning",
+    iconWrapperClassName: "bg-warning/10 text-warning",
+  },
+} satisfies Record<StateKind, StateViewDefinition>;
+
+export type StateViewProps = {
+  kind: StateKind;
+  icon?: LucideIcon;
+  title?: string;
+  description?: string | null;
+  action?: ReactNode;
+  recommendedAction?: ReactNode;
+  secondaryAction?: ReactNode;
+  className?: string;
+};
+
+export function StateView({
+  kind,
+  icon,
+  title,
+  description,
+  action,
+  recommendedAction,
+  secondaryAction,
+  className,
+}: StateViewProps) {
+  const state = STATE_VIEW_COPY[kind];
+  const Icon = icon ?? state.icon;
+  const resolvedDescription =
+    description === undefined ? state.description : description;
+  const primaryAction = recommendedAction ?? action;
+
+  return (
+    <div
+      role={state.role}
+      aria-live={state.live}
+      aria-busy={kind === "loading" ? true : undefined}
+      className={cn(
+        "flex flex-col items-center justify-center border border-dashed px-6 py-14 text-center",
+        state.surfaceClassName,
+        className
+      )}
+    >
+      <div
+        className={cn(
+          "mb-4 flex size-14 items-center justify-center",
+          state.iconWrapperClassName
+        )}
+      >
+        <Icon
+          className={cn("size-7", state.iconClassName)}
+          aria-hidden="true"
+        />
+      </div>
+      <h3 className="text-base font-semibold text-foreground">
+        {title ?? state.title}
+      </h3>
+      {resolvedDescription ? (
+        <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+          {resolvedDescription}
+        </p>
+      ) : null}
+      {primaryAction || secondaryAction ? (
+        <div className="mt-5 flex w-full flex-col items-center justify-center gap-2 sm:w-auto sm:flex-row">
+          {primaryAction ? (
+            <div className="w-full sm:w-auto">{primaryAction}</div>
+          ) : null}
+          {secondaryAction ? (
+            <div className="w-full sm:w-auto">{secondaryAction}</div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function EmptyState({
- icon: Icon,
- title,
- description,
- action,
- className,
+  icon: Icon,
+  kind,
+  variant,
+  title,
+  description,
+  action,
+  recommendedAction,
+  secondaryAction,
+  className,
 }: {
- icon: LucideIcon;
- title: string;
- description?: string;
- action?: ReactNode;
- className?: string;
+  icon?: LucideIcon;
+  kind?: EmptyStateVariant;
+  variant?: EmptyStateVariant;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  recommendedAction?: ReactNode;
+  secondaryAction?: ReactNode;
+  className?: string;
 }) {
- return (
- <div
- className={cn(
- "flex flex-col items-center justify-center border border-dashed bg-card/40 px-6 py-14 text-center",
- className
- )}
- >
- <div className="mb-4 flex size-14 items-center justify-center bg-gradient-to-br from-primary/20 to-primary/5 text-primary">
- <Icon className="size-7" />
- </div>
- <h3 className="text-base font-semibold text-foreground">{title}</h3>
- {description ? (
- <p className="mt-1 max-w-sm text-sm text-muted-foreground">
- {description}
- </p>
- ) : null}
- {action ? <div className="mt-5">{action}</div> : null}
- </div>
- );
+  return (
+    <StateView
+      kind={variant ?? kind ?? "empty"}
+      icon={Icon}
+      title={title}
+      description={description ?? null}
+      action={action}
+      recommendedAction={recommendedAction}
+      secondaryAction={secondaryAction}
+      className={className}
+    />
+  );
+}
+
+type PresetStateProps = Omit<StateViewProps, "kind">;
+
+export function LoadingState(props: PresetStateProps) {
+  return <StateView kind="loading" {...props} />;
+}
+
+export function ErrorState(props: PresetStateProps) {
+  return <StateView kind="error" {...props} />;
+}
+
+export function PermissionState(props: PresetStateProps) {
+  return <StateView kind="permission" {...props} />;
+}
+
+export function OfflineState(props: PresetStateProps) {
+  return <StateView kind="offline" {...props} />;
+}
+
+export function WarningState(props: PresetStateProps) {
+  return <StateView kind="warning" {...props} />;
+}
+
+export type ApiErrorStateProps = Omit<
+  StateViewProps,
+  "kind" | "title" | "description"
+> &
+  ApiErrorStateCopyOptions & {
+    error: unknown;
+    title?: string;
+    description?: string | null;
+  };
+
+export function ApiErrorState({
+  error,
+  resourceName,
+  isOnline,
+  overrides,
+  title,
+  description,
+  ...props
+}: ApiErrorStateProps) {
+  const state = getApiErrorStateCopy(error, {
+    resourceName,
+    isOnline,
+    overrides,
+  });
+
+  return (
+    <StateView
+      kind={state.kind}
+      title={title ?? state.title}
+      description={description === undefined ? state.description : description}
+      {...props}
+    />
+  );
 }

--- a/apps/console/src/components/common/RetryButton.tsx
+++ b/apps/console/src/components/common/RetryButton.tsx
@@ -1,0 +1,34 @@
+import type { ComponentProps } from "react";
+import { Loader2, RefreshCw } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+
+type RetryButtonProps = ComponentProps<typeof Button> & {
+  isRetrying?: boolean;
+};
+
+export function RetryButton({
+  children = "Retry",
+  disabled = false,
+  isRetrying = false,
+  type = "button",
+  variant = "outline",
+  ...props
+}: RetryButtonProps) {
+  return (
+    <Button
+      type={type}
+      variant={variant}
+      disabled={disabled || isRetrying}
+      aria-disabled={disabled || isRetrying}
+      {...props}
+    >
+      {isRetrying ? (
+        <Loader2 className="animate-spin" aria-hidden="true" />
+      ) : (
+        <RefreshCw aria-hidden="true" />
+      )}
+      {isRetrying ? "Retrying" : children}
+    </Button>
+  );
+}

--- a/apps/console/src/components/common/skeletons.tsx
+++ b/apps/console/src/components/common/skeletons.tsx
@@ -1,4 +1,57 @@
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/src/components/common/PageHeader";
 import { Skeleton } from "@/src/components/ui/skeleton";
+
+function LoadingRegion({
+ label,
+ children,
+ className = "flex flex-col gap-6",
+}: {
+ label: string;
+ children: ReactNode;
+ className?: string;
+}) {
+ return (
+ <div
+ role="status"
+ aria-label={label}
+ aria-live="polite"
+ aria-busy="true"
+ aria-atomic="true"
+ className={className}
+ >
+ <span className="sr-only">{label}</span>
+ <div aria-hidden="true" className={className}>
+ {children}
+ </div>
+ </div>
+ );
+}
+
+function DashboardCardSkeleton({
+ className = "",
+ compact = false,
+}: {
+ className?: string;
+ compact?: boolean;
+}) {
+ return (
+ <div className={`border bg-card p-5 ${className}`}>
+ <div className="flex items-start justify-between gap-4">
+ <div className="space-y-2">
+ <Skeleton className="h-3 w-28" />
+ <Skeleton className={compact ? "h-6 w-16" : "h-8 w-24"} />
+ </div>
+ <Skeleton className="size-8" />
+ </div>
+ <div className="mt-5 space-y-2">
+ <Skeleton className="h-3 w-full" />
+ <Skeleton className="h-3 w-3/4" />
+ </div>
+ </div>
+ );
+}
 
 export function PageSkeleton() {
  return (
@@ -33,5 +86,177 @@ export function CardGridSkeleton({ count = 6 }: { count?: number }) {
  <Skeleton key={i} className="h-44 " />
  ))}
  </div>
+ );
+}
+
+export function DashboardLoadingSkeleton() {
+ return (
+ <LoadingRegion label="Loading dashboard summary">
+ <PageHeader
+ title="Dashboard"
+ description="A compact view of call volume, outcomes, routing, and agent performance."
+ actions={
+ <div aria-label="Dashboard date range" className="space-y-2 sm:w-56">
+ <div className="grid grid-cols-3 gap-1 border bg-background p-1">
+ <Skeleton className="h-8 w-full" />
+ <Skeleton className="h-8 w-full" />
+ <Skeleton className="h-8 w-full" />
+ </div>
+ <Skeleton className="ml-auto h-3 w-32" />
+ </div>
+ }
+ />
+
+ <div className="flex flex-col gap-3 border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+ <div className="space-y-2">
+ <Skeleton className="h-4 w-40" />
+ <Skeleton className="h-3 w-64 max-w-full" />
+ </div>
+ <Skeleton className="h-9 w-28" />
+ </div>
+
+ <section className="grid gap-4 border bg-card p-5 lg:grid-cols-[1fr_340px] lg:items-center">
+ <div className="space-y-3">
+ <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+ Operations snapshot
+ </p>
+ <Skeleton className="h-7 w-72 max-w-full" />
+ <Skeleton className="h-4 w-full max-w-2xl" />
+ </div>
+ <div className="grid grid-cols-3 border bg-background text-center">
+ {["minutes", "exceptions", "agents"].map((label, index) => (
+ <div
+ key={label}
+ className={index < 2 ? "border-r px-3 py-3" : "px-3 py-3"}
+ >
+ <Skeleton className="mx-auto h-6 w-10" />
+ <p className="mt-2 text-xs text-muted-foreground">{label}</p>
+ </div>
+ ))}
+ </div>
+ </section>
+
+ <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-12">
+ <DashboardCardSkeleton className="xl:col-span-3" />
+ <DashboardCardSkeleton className="xl:col-span-2" />
+ <DashboardCardSkeleton className="xl:col-span-2" />
+ <DashboardCardSkeleton className="xl:col-span-2" />
+ <div className="grid grid-cols-2 gap-4 xl:col-span-3">
+ <DashboardCardSkeleton compact />
+ <DashboardCardSkeleton compact />
+ </div>
+ </div>
+
+ <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+ <section className="border bg-card xl:col-span-2">
+ <div className="flex flex-col gap-4 border-b p-5 xl:flex-row xl:items-end xl:justify-between">
+ <div className="space-y-2">
+ <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+ Traffic timeline
+ </p>
+ <Skeleton className="h-6 w-72 max-w-full" />
+ <Skeleton className="h-4 w-full max-w-xl" />
+ </div>
+ <div className="grid grid-cols-3 border bg-background text-center sm:min-w-96">
+ {["calls", "minutes", "peak"].map((label, index) => (
+ <div
+ key={label}
+ className={index < 2 ? "border-r px-3 py-2" : "px-3 py-2"}
+ >
+ <Skeleton className="mx-auto h-4 w-8" />
+ <p className="mt-1 text-xs text-muted-foreground">{label}</p>
+ </div>
+ ))}
+ </div>
+ </div>
+ <Skeleton className="m-5 h-80 w-[calc(100%-2.5rem)]" />
+ <div className="grid gap-2 px-5 pb-5 sm:grid-cols-3">
+ <Skeleton className="h-4 w-full" />
+ <Skeleton className="h-4 w-full" />
+ <Skeleton className="h-4 w-full" />
+ </div>
+ </section>
+
+ <section className="border bg-card">
+ <div className="flex items-center justify-between border-b px-5 py-4">
+ <div className="space-y-2">
+ <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+ Agent activity
+ </p>
+ <Skeleton className="h-5 w-28" />
+ <Skeleton className="h-3 w-44" />
+ </div>
+ <Skeleton className="h-4 w-16" />
+ </div>
+ <div className="grid grid-cols-2 border-b bg-muted/20 text-xs">
+ <div className="border-r px-5 py-3">
+ <Skeleton className="h-4 w-8" />
+ <p className="mt-1 text-muted-foreground">active agents</p>
+ </div>
+ <div className="px-5 py-3">
+ <Skeleton className="h-4 w-8" />
+ <p className="mt-1 text-muted-foreground">assigned calls</p>
+ </div>
+ </div>
+ <div className="space-y-4 p-5">
+ {Array.from({ length: 5 }).map((_, index) => (
+ <div key={index} className="border bg-background p-3">
+ <div className="flex items-start gap-3">
+ <Skeleton className="size-8 shrink-0" />
+ <div className="min-w-0 flex-1 space-y-3">
+ <div className="flex justify-between gap-3">
+ <div className="space-y-2">
+ <Skeleton className="h-4 w-36" />
+ <Skeleton className="h-3 w-44" />
+ </div>
+ <Skeleton className="h-8 w-14" />
+ </div>
+ <Skeleton className="h-2 w-full" />
+ </div>
+ </div>
+ </div>
+ ))}
+ </div>
+ </section>
+ </div>
+
+ <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+ {["Call outcomes", "Direction mix"].map((title) => (
+ <section key={title} className="border bg-card p-5">
+ <div className="mb-5 flex items-start justify-between gap-4">
+ <div className="space-y-2">
+ <Skeleton className="h-3 w-20" />
+ <h3 className="text-base font-semibold text-foreground">{title}</h3>
+ <Skeleton className="h-3 w-60 max-w-full" />
+ </div>
+ <Skeleton className="h-12 w-20" />
+ </div>
+ <Skeleton className="h-64 w-full" />
+ </section>
+ ))}
+ </div>
+
+ <section className="border bg-card">
+ <div className="flex items-center justify-between border-b px-5 py-4">
+ <div>
+ <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+ Recent activity
+ </p>
+ <h3 className="mt-1 text-base font-semibold text-foreground">
+ Recent call logs
+ </h3>
+ <p className="text-xs text-muted-foreground">
+ Latest call log activity across all agents.
+ </p>
+ </div>
+ <Skeleton className="h-4 w-24" />
+ </div>
+ <div className="space-y-2 p-5">
+ {Array.from({ length: 6 }).map((_, index) => (
+ <Skeleton key={index} className="h-14 w-full" />
+ ))}
+ </div>
+ </section>
+ </LoadingRegion>
  );
 }

--- a/apps/console/src/components/dashboard/AgentActivityList.tsx
+++ b/apps/console/src/components/dashboard/AgentActivityList.tsx
@@ -1,26 +1,64 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, Bot, CheckCircle2, PhoneCall } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Bot,
+  CheckCircle2,
+  PhoneCall,
+} from "lucide-react";
+import { Button } from "@/src/components/ui/button";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { EmptyState } from "@/src/components/common/EmptyState";
 import { useAgents } from "@/src/hooks/queries/agents";
-import type { DashboardSummary } from "@/src/lib/api/resources/dashboard";
+import { dashboardCallsHref } from "@/src/components/dashboard/call-filter-links";
+import type {
+  AgentBucket,
+  DashboardRange,
+  DashboardSummary,
+} from "@/src/lib/api/resources/dashboard";
+import type { Agent } from "@/src/lib/api/types";
+
+function resolveAgentName({
+  agent,
+  agents,
+  agentsLoading,
+  agentsError,
+}: {
+  agent: AgentBucket;
+  agents?: Agent[];
+  agentsLoading: boolean;
+  agentsError: boolean;
+}) {
+  if (!agent.agentId) return "Unassigned";
+  if (agentsLoading) return "Resolving agent";
+  if (agentsError) return "Agent name unavailable";
+  return (
+    agents?.find((knownAgent) => knownAgent.agentId === agent.agentId)?.name ??
+    "Unknown agent"
+  );
+}
 
 export function AgentActivityList({
   summary,
+  range,
   loading,
 }: {
   summary?: DashboardSummary;
+  range: DashboardRange;
   loading?: boolean;
 }) {
-  const { data: agents } = useAgents();
-  const nameFor = (id: string | null) =>
-    agents?.find((agent) => agent.agentId === id)?.name ?? "Unassigned";
+  const {
+    data: agents,
+    isLoading: agentsLoading,
+    isError: agentsError,
+  } = useAgents();
 
   const top = summary?.topAgents ?? [];
   const max = top[0]?.calls ?? 1;
   const totalCalls = top.reduce((sum, agent) => sum + agent.calls, 0);
+  const hasAgentLookupGap = agentsError && top.some((agent) => agent.agentId);
 
   return (
     <div className="border bg-card">
@@ -51,6 +89,20 @@ export function AgentActivityList({
           <p className="text-muted-foreground">assigned calls</p>
         </div>
       </div>
+      {hasAgentLookupGap ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-start gap-2 border-b border-amber-500/30 bg-amber-500/10 px-5 py-3 text-xs text-amber-800 dark:text-amber-200"
+        >
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+          <span>
+            <span className="font-semibold">Partial agent data:</span> call
+            counts loaded, but agent names could not be resolved. Use the call
+            links to inspect the source records.
+          </span>
+        </div>
+      ) : null}
       {loading ? (
         <div className="space-y-4 p-5">
           {[...Array(5)].map((_, i) => (
@@ -63,14 +115,35 @@ export function AgentActivityList({
           title="No agent activity"
           description="Create an agent and connect it to a number to see activity."
           className="border-0"
+          action={
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button asChild size="sm">
+                <Link href="/agents">Create agent</Link>
+              </Button>
+              <Button asChild size="sm" variant="outline">
+                <Link href="/numbers">Connect number</Link>
+              </Button>
+            </div>
+          }
         />
       ) : (
         <div className="space-y-4 p-5">
           {top.map((agent, index) => {
             const pct = Math.max(4, Math.round((agent.calls / max) * 100));
             const successPct = Math.round(agent.successRate * 100);
+            const agentName = resolveAgentName({
+              agent,
+              agents,
+              agentsLoading,
+              agentsError,
+            });
             return (
-              <div key={agent.agentId ?? "unknown"} className="border bg-background p-3">
+              <Link
+                key={agent.agentId ?? "unknown"}
+                href={dashboardCallsHref({ range, agentId: agent.agentId })}
+                className="group block border bg-background p-3 transition-colors hover:border-primary/35 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                aria-label={`View calls for ${agentName} in the selected dashboard range`}
+              >
                 <div className="flex items-start gap-3">
                   <div className="flex size-8 shrink-0 items-center justify-center border bg-card text-xs font-semibold text-muted-foreground">
                     {index + 1}
@@ -79,7 +152,7 @@ export function AgentActivityList({
                     <div className="flex items-start justify-between gap-3 text-sm">
                       <div className="min-w-0">
                         <p className="truncate font-medium text-foreground">
-                          {nameFor(agent.agentId)}
+                          {agentName}
                         </p>
                         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
                           <span className="inline-flex items-center gap-1">
@@ -95,6 +168,10 @@ export function AgentActivityList({
                       <div className="shrink-0 text-right text-xs text-muted-foreground">
                         <p className="font-semibold text-foreground">{agent.minutes}m</p>
                         <p>talk time</p>
+                        <p className="mt-1 inline-flex items-center gap-1 font-medium text-primary">
+                          View calls
+                          <ArrowRight className="size-3 transition-transform group-hover:translate-x-0.5" />
+                        </p>
                       </div>
                     </div>
                     <div className="h-2 w-full overflow-hidden bg-muted">
@@ -105,7 +182,7 @@ export function AgentActivityList({
                     </div>
                   </div>
                 </div>
-              </div>
+              </Link>
             );
           })}
         </div>

--- a/apps/console/src/components/dashboard/BreakdownCharts.tsx
+++ b/apps/console/src/components/dashboard/BreakdownCharts.tsx
@@ -1,14 +1,23 @@
 "use client";
 
+import { useId } from "react";
+import Link from "next/link";
 import { Bar, BarChart, Cell, Pie, PieChart, XAxis, YAxis } from "recharts";
+import { ArrowRight, PhoneCall } from "lucide-react";
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
   type ChartConfig,
 } from "@/src/components/ui/chart";
+import { Button } from "@/src/components/ui/button";
 import { Skeleton } from "@/src/components/ui/skeleton";
-import type { DashboardSummary } from "@/src/lib/api/resources/dashboard";
+import { EmptyState } from "@/src/components/common/EmptyState";
+import { dashboardCallsHref } from "@/src/components/dashboard/call-filter-links";
+import type {
+  DashboardRange,
+  DashboardSummary,
+} from "@/src/lib/api/resources/dashboard";
 
 const statusConfig = {
   count: { label: "Calls", color: "var(--chart-1)" },
@@ -35,17 +44,43 @@ const statusColors: Record<string, string> = {
   PROCESSED: "var(--chart-4)",
 };
 
+const statusPattern: Record<string, string> = {
+  COMPLETED: "solid bar",
+  FAILED: "dashed bar",
+  NOT_ANSWERED: "dotted bar",
+  IN_PROGRESS: "striped bar",
+  SCHEDULED: "outlined bar",
+  PROCESSED: "double-line bar",
+};
+
+const directionPattern = {
+  inbound: "filled segment",
+  outbound: "outlined segment",
+  unknown: "dashed segment",
+};
+
 function labelStatus(status: string) {
   return status.toLowerCase().replace("_", " ");
 }
 
+function percent(count: number, total: number) {
+  return total ? Math.round((count / total) * 100) : 0;
+}
+
 export function BreakdownCharts({
   summary,
+  range,
   loading,
 }: {
   summary?: DashboardSummary;
+  range: DashboardRange;
   loading?: boolean;
 }) {
+  const statusTitleId = useId();
+  const statusSummaryId = useId();
+  const directionTitleId = useId();
+  const directionSummaryId = useId();
+
   if (loading) {
     return (
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
@@ -67,20 +102,36 @@ export function BreakdownCharts({
   const inboundPct = directionTotal
     ? Math.round((inbound / directionTotal) * 100)
     : 0;
+  const statusChartData = statusData.map((item) => ({
+    ...item,
+    label: labelStatus(item.status),
+    pattern: statusPattern[item.status] ?? "solid bar",
+    percentage: percent(item.count, totalStatus),
+  }));
+  const directionChartData = directionData.map((item) => ({
+    ...item,
+    label: item.direction,
+    pattern: directionPattern[item.direction],
+    percentage: percent(item.count, directionTotal),
+  }));
 
   return (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-      <div className="border bg-card p-5">
+      <div className="border bg-card p-5" aria-labelledby={statusTitleId}>
         <div className="mb-5 flex items-start justify-between gap-4">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Outcomes
             </p>
-            <h3 className="mt-1 text-base font-semibold text-foreground">
+            <h3
+              id={statusTitleId}
+              className="mt-1 text-base font-semibold text-foreground"
+            >
               Call outcomes
             </h3>
-            <p className="text-xs text-muted-foreground">
-              Status distribution for the selected range.
+            <p id={statusSummaryId} className="text-xs text-muted-foreground">
+              Status distribution for the selected range. X-axis shows calls;
+              Y-axis shows call status.
             </p>
           </div>
           <div className="border bg-background px-3 py-2 text-right">
@@ -89,52 +140,143 @@ export function BreakdownCharts({
           </div>
         </div>
         {statusData.length ? (
-          <ChartContainer config={statusConfig} className="h-64 w-full">
-            <BarChart
-              data={statusData.map((item) => ({
-                ...item,
-                label: labelStatus(item.status),
-              }))}
-              layout="vertical"
-              margin={{ top: 0, right: 16, left: 12, bottom: 0 }}
+          <>
+            <ChartContainer
+              config={statusConfig}
+              className="h-64 w-full"
+              role="group"
+              aria-label="Call outcome status breakdown chart"
             >
-              <XAxis type="number" hide />
-              <YAxis
-                type="category"
-                dataKey="label"
-                width={104}
-                tickLine={false}
-                axisLine={false}
-                className="text-xs text-muted-foreground"
-              />
-              <ChartTooltip content={<ChartTooltipContent hideLabel />} />
-              <Bar dataKey="count" barSize={18}>
-                {statusData.map((item) => (
-                  <Cell
-                    key={item.status}
-                    fill={statusColors[item.status] ?? "var(--color-count)"}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ChartContainer>
+              <BarChart
+                accessibilityLayer
+                data={statusChartData}
+                layout="vertical"
+                margin={{ top: 0, right: 16, left: 18, bottom: 24 }}
+                aria-label="Call outcome status breakdown chart"
+                aria-describedby={statusSummaryId}
+              >
+                <XAxis
+                  type="number"
+                  tickLine={false}
+                  axisLine={false}
+                  className="text-xs text-muted-foreground"
+                  label={{
+                    value: "Calls",
+                    position: "insideBottom",
+                    offset: -12,
+                  }}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="label"
+                  width={112}
+                  tickLine={false}
+                  axisLine={false}
+                  className="text-xs text-muted-foreground"
+                  label={{
+                    value: "Status",
+                    angle: -90,
+                    position: "insideLeft",
+                  }}
+                />
+                <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+                <Bar dataKey="count" name="Calls" barSize={18}>
+                  {statusData.map((item) => (
+                    <Cell
+                      key={item.status}
+                      fill={statusColors[item.status] ?? "var(--color-count)"}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ChartContainer>
+            <div className="mt-4 grid gap-2 sm:grid-cols-2">
+              {statusData.map((item) => (
+                <Link
+                  key={item.status}
+                  href={dashboardCallsHref({ range, status: item.status })}
+                  className="group flex items-center justify-between gap-3 border bg-background px-3 py-2 text-sm transition-colors hover:border-primary/35 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  aria-label={`Review ${labelStatus(item.status)} calls in the selected dashboard range`}
+                >
+                  <span className="min-w-0">
+                    <span className="flex items-center gap-2">
+                      <span
+                        aria-hidden
+                        className="size-2 shrink-0"
+                        style={{
+                          background:
+                            statusColors[item.status] ?? "var(--color-count)",
+                        }}
+                      />
+                      <span className="truncate capitalize text-foreground">
+                        {labelStatus(item.status)}
+                      </span>
+                    </span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      {item.count} calls,{" "}
+                      {statusPattern[item.status] ?? "solid bar"}
+                    </span>
+                  </span>
+                  <span className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-primary">
+                    Review
+                    <ArrowRight className="size-3 transition-transform group-hover:translate-x-0.5" />
+                  </span>
+                </Link>
+              ))}
+            </div>
+            <div className="sr-only">
+              <table aria-describedby={statusSummaryId}>
+                <caption>Call outcome status breakdown data table</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Status</th>
+                    <th scope="col">Calls</th>
+                    <th scope="col">Percentage of calls</th>
+                    <th scope="col">Legend pattern</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {statusChartData.map((item) => (
+                    <tr key={item.status}>
+                      <th scope="row">{item.label}</th>
+                      <td>{item.count}</td>
+                      <td>{item.percentage}%</td>
+                      <td>{item.pattern}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         ) : (
-          <div className="flex h-64 items-center justify-center border border-dashed text-sm text-muted-foreground">
-            No outcomes yet.
-          </div>
+          <EmptyState
+            icon={PhoneCall}
+            title="No outcomes yet"
+            description="Place a test call to confirm completion, failed, and missed call states are flowing into reporting."
+            className="h-64 bg-background/40"
+            action={
+              <Button asChild size="sm">
+                <Link href="/outbound">Place a test call</Link>
+              </Button>
+            }
+          />
         )}
       </div>
-      <div className="border bg-card p-5">
+      <div className="border bg-card p-5" aria-labelledby={directionTitleId}>
         <div className="mb-5 flex items-start justify-between gap-4">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Routing
             </p>
-            <h3 className="mt-1 text-base font-semibold text-foreground">
+            <h3
+              id={directionTitleId}
+              className="mt-1 text-base font-semibold text-foreground"
+            >
               Direction mix
             </h3>
-            <p className="text-xs text-muted-foreground">
-              Inbound and outbound call composition.
+            <p id={directionSummaryId} className="text-xs text-muted-foreground">
+              Inbound and outbound call composition by count and share of
+              routed calls.
             </p>
           </div>
           <div className="border bg-background px-3 py-2 text-right">
@@ -144,13 +286,22 @@ export function BreakdownCharts({
         </div>
         {directionData.length ? (
           <div className="grid gap-4 md:grid-cols-[1fr_200px]">
-            <ChartContainer config={directionConfig} className="h-64 w-full">
-              <PieChart>
+            <ChartContainer
+              config={directionConfig}
+              className="h-64 w-full"
+              role="group"
+              aria-label="Inbound and outbound direction mix chart"
+            >
+              <PieChart
+                accessibilityLayer
+                aria-label="Inbound and outbound direction mix chart"
+                aria-describedby={directionSummaryId}
+              >
                 <ChartTooltip content={<ChartTooltipContent hideLabel />} />
                 <Pie
-                  data={directionData}
+                  data={directionChartData}
                   dataKey="count"
-                  nameKey="direction"
+                  nameKey="label"
                   innerRadius={54}
                   outerRadius={92}
                   paddingAngle={2}
@@ -165,7 +316,7 @@ export function BreakdownCharts({
               </PieChart>
             </ChartContainer>
             <div className="flex flex-col justify-center gap-3">
-              {directionData.map((item) => (
+              {directionChartData.map((item) => (
                 <div key={item.direction} className="border px-3 py-2 text-sm">
                   <div className="flex items-center justify-between">
                     <span className="capitalize text-muted-foreground">
@@ -173,6 +324,9 @@ export function BreakdownCharts({
                     </span>
                     <span className="font-semibold text-foreground">{item.count}</span>
                   </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {item.percentage}% of routed calls, {item.pattern}
+                  </p>
                   <div className="mt-2 h-1.5 bg-muted">
                     <div
                       className="h-full"
@@ -190,11 +344,47 @@ export function BreakdownCharts({
                 </div>
               ))}
             </div>
+            <div className="sr-only">
+              <table aria-describedby={directionSummaryId}>
+                <caption>Inbound and outbound direction mix data table</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Direction</th>
+                    <th scope="col">Calls</th>
+                    <th scope="col">Percentage of routed calls</th>
+                    <th scope="col">Legend pattern</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {directionChartData.map((item) => (
+                    <tr key={item.direction}>
+                      <th scope="row">{item.label}</th>
+                      <td>{item.count}</td>
+                      <td>{item.percentage}%</td>
+                      <td>{item.pattern}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         ) : (
-          <div className="flex h-64 items-center justify-center border border-dashed text-sm text-muted-foreground">
-            No direction data yet.
-          </div>
+          <EmptyState
+            icon={ArrowRight}
+            title="No routing data yet"
+            description="Connect a number or place a test call to see inbound and outbound routing mix."
+            className="h-64 bg-background/40"
+            action={
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button asChild size="sm">
+                  <Link href="/numbers">Connect a number</Link>
+                </Button>
+                <Button asChild size="sm" variant="outline">
+                  <Link href="/outbound">Place a test call</Link>
+                </Button>
+              </div>
+            }
+          />
         )}
       </div>
     </div>

--- a/apps/console/src/components/dashboard/DashboardFreshness.tsx
+++ b/apps/console/src/components/dashboard/DashboardFreshness.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Clock3, RefreshCw, WifiOff } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import type { DashboardSummary } from "@/src/lib/api/resources/dashboard";
+
+const DATE_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "UTC",
+  timeZoneName: "short",
+};
+
+function formatDateTime(value?: string | number) {
+  if (!value) return "Not available";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not available";
+  return date.toLocaleString("en-US", DATE_TIME_FORMAT);
+}
+
+export function DashboardFreshness({
+  summary,
+  loading,
+  dataUpdatedAt,
+  isFetching,
+  isStale,
+  onRefresh,
+}: {
+  summary?: DashboardSummary;
+  loading?: boolean;
+  dataUpdatedAt: number;
+  isFetching: boolean;
+  isStale: boolean;
+  onRefresh: () => void;
+}) {
+  const [isOnline, setIsOnline] = useState(true);
+  const hasData = Boolean(summary);
+  const showStale = hasData && isStale && !isFetching;
+
+  useEffect(() => {
+    function syncOnlineState() {
+      setIsOnline(navigator.onLine);
+    }
+
+    syncOnlineState();
+    window.addEventListener("online", syncOnlineState);
+    window.addEventListener("offline", syncOnlineState);
+
+    return () => {
+      window.removeEventListener("online", syncOnlineState);
+      window.removeEventListener("offline", syncOnlineState);
+    };
+  }, []);
+
+  return (
+    <section
+      aria-busy={isFetching}
+      aria-live="polite"
+      className="border bg-card p-4"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="grid gap-3 text-sm sm:grid-cols-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Reporting window
+            </p>
+            <p className="mt-1 text-foreground">
+              {loading || !summary
+                ? "Loading selected period"
+                : `${formatDateTime(summary.period.from)} to ${formatDateTime(
+                    summary.period.to
+                  )}`}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Last updated
+            </p>
+            <p className="mt-1 inline-flex items-center gap-2 text-foreground">
+              <Clock3 className="size-4 text-muted-foreground" />
+              {dataUpdatedAt ? formatDateTime(dataUpdatedAt) : "Not updated yet"}
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onRefresh}
+          disabled={isFetching || !isOnline}
+          aria-label="Refresh dashboard"
+          className="w-full sm:w-fit"
+        >
+          <RefreshCw className={isFetching ? "animate-spin" : undefined} />
+          {isFetching ? "Refreshing" : "Refresh dashboard"}
+        </Button>
+      </div>
+      {!isOnline ? (
+        <div className="mt-3 flex items-start gap-2 border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-200">
+          <WifiOff className="mt-0.5 size-3.5 shrink-0" />
+          <span>
+            You are offline.{" "}
+            {hasData
+              ? "Showing the last loaded dashboard data until your connection returns."
+              : "Reconnect to load dashboard data."}
+          </span>
+        </div>
+      ) : showStale ? (
+        <div className="mt-3 border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          Dashboard data is stale. Refresh to confirm the latest call activity.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/console/src/components/dashboard/KpiCards.tsx
+++ b/apps/console/src/components/dashboard/KpiCards.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
+import type { ReactNode } from "react";
 import {
   AlertTriangle,
+  ArrowRight,
   CheckCircle2,
   Clock,
   PhoneCall,
@@ -11,7 +14,26 @@ import {
   Voicemail,
 } from "lucide-react";
 import { StatCard } from "@/src/components/common/StatCard";
-import type { DashboardSummary } from "@/src/lib/api/resources/dashboard";
+import { dashboardCallsHref } from "@/src/components/dashboard/call-filter-links";
+import type {
+  DashboardRange,
+  DashboardSummary,
+} from "@/src/lib/api/resources/dashboard";
+
+const PREVIOUS_PERIOD_LABELS: Record<DashboardSummary["range"], string> = {
+  "24h": "previous 24 hours",
+  "7d": "previous 7 days",
+  "30d": "previous 30 days",
+};
+
+const PERIOD_BOUNDARY_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  timeZone: "UTC",
+});
+
+type DeltaUnit = "call" | "minute" | "second" | "percentage point";
 
 function formatDuration(seconds: number) {
   if (!seconds) return "0s";
@@ -21,20 +43,58 @@ function formatDuration(seconds: number) {
   return `${m}m ${s}s`;
 }
 
-function formatDeltaValue(value?: number, suffix = "%") {
+function formatPeriodBoundary(value?: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return PERIOD_BOUNDARY_FORMAT.format(date);
+}
+
+function formatPreviousPeriodLabel(summary?: DashboardSummary) {
+  if (!summary) return "selected comparison period";
+
+  const rangeLabel = PREVIOUS_PERIOD_LABELS[summary.range];
+  const previousFrom = formatPeriodBoundary(summary.period.previousFrom);
+  const previousTo = formatPeriodBoundary(summary.period.previousTo);
+
+  if (!previousFrom || !previousTo) return rangeLabel;
+  return `${rangeLabel}, ${previousFrom} to ${previousTo} UTC`;
+}
+
+function normalizeDeltaValue(value: number | undefined, unit: DeltaUnit) {
   const n = value ?? 0;
-  const sign = n > 0 ? "+" : "";
-  return `${sign}${n}${suffix}`;
+  const amount =
+    unit === "percentage point" && Math.abs(n) <= 1 ? n * 100 : n;
+
+  return Math.abs(amount) < 0.05 ? 0 : amount;
+}
+
+function formatDeltaAmount(value: number) {
+  return value.toLocaleString("en-US", {
+    maximumFractionDigits: Number.isInteger(value) ? 0 : 1,
+  });
+}
+
+function formatDeltaCopy(value: number | undefined, unit: DeltaUnit) {
+  const amount = normalizeDeltaValue(value, unit);
+  const sign = amount > 0 ? "+" : "";
+  const unitLabel = Math.abs(amount) === 1 ? unit : `${unit}s`;
+
+  return `${sign}${formatDeltaAmount(amount)} ${unitLabel}`;
 }
 
 function Trend({
   value,
+  unit,
+  comparisonLabel,
   inverse = false,
 }: {
   value?: number;
+  unit: DeltaUnit;
+  comparisonLabel: string;
   inverse?: boolean;
 }) {
-  const n = value ?? 0;
+  const n = normalizeDeltaValue(value, unit);
   const positive = n >= 0;
   const good = inverse ? n <= 0 : n >= 0;
   const Icon = positive ? TrendingUp : TrendingDown;
@@ -48,20 +108,43 @@ function Trend({
       }
     >
       <Icon className="size-3" />
-      {formatDeltaValue(n)} vs previous
+      {formatDeltaCopy(value, unit)} vs {comparisonLabel}
     </span>
   );
 }
 
+function InvestigationHint({
+  action,
+  children,
+}: {
+  action: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      {children}
+      <span className="inline-flex items-center gap-1 text-primary">
+        {action} <ArrowRight className="size-3" />
+      </span>
+    </div>
+  );
+}
+
+const drilldownLinkClass =
+  "block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
 export function KpiCards({
   summary,
+  range,
   loading,
 }: {
   summary?: DashboardSummary;
+  range: DashboardRange;
   loading?: boolean;
 }) {
   const totals = summary?.totals;
   const deltas = summary?.deltas;
+  const previousPeriodLabel = formatPreviousPeriodLabel(summary);
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-12">
@@ -69,7 +152,15 @@ export function KpiCards({
         label="Total calls"
         value={totals?.calls.toLocaleString() ?? "0"}
         eyebrow="All inbound and outbound activity"
-        helper={<Trend value={deltas?.calls} />}
+        helper={
+          deltas ? (
+            <Trend
+              value={deltas.calls}
+              unit="call"
+              comparisonLabel={previousPeriodLabel}
+            />
+          ) : undefined
+        }
         icon={PhoneCall}
         loading={loading}
         tone="info"
@@ -79,7 +170,15 @@ export function KpiCards({
         label="Minutes used"
         value={totals?.minutes.toLocaleString() ?? "0"}
         eyebrow="Connected conversation time"
-        helper={<Trend value={deltas?.minutes} />}
+        helper={
+          deltas ? (
+            <Trend
+              value={deltas.minutes}
+              unit="minute"
+              comparisonLabel={previousPeriodLabel}
+            />
+          ) : undefined
+        }
         icon={Clock}
         loading={loading}
         tone="neutral"
@@ -89,7 +188,15 @@ export function KpiCards({
         label="Avg duration"
         value={formatDuration(totals?.avgDurationSeconds ?? 0)}
         eyebrow="Per completed interaction"
-        helper={<Trend value={deltas?.avgDurationSeconds} />}
+        helper={
+          deltas ? (
+            <Trend
+              value={deltas.avgDurationSeconds}
+              unit="second"
+              comparisonLabel={previousPeriodLabel}
+            />
+          ) : undefined
+        }
         icon={Timer}
         loading={loading}
         tone="warning"
@@ -99,29 +206,73 @@ export function KpiCards({
         label="Success rate"
         value={`${Math.round((totals?.successRate ?? 0) * 100)}%`}
         eyebrow="Completed calls out of total"
-        helper={<Trend value={deltas?.successRate} />}
+        helper={
+          deltas ? (
+            <Trend
+              value={deltas.successRate}
+              unit="percentage point"
+              comparisonLabel={previousPeriodLabel}
+            />
+          ) : undefined
+        }
         icon={CheckCircle2}
         loading={loading}
         tone="success"
         className="xl:col-span-2"
       />
       <div className="grid grid-cols-2 gap-4 xl:col-span-3">
-        <StatCard
-          label="Failed"
-          value={totals?.failedCalls.toLocaleString() ?? "0"}
-          helper={<Trend value={deltas?.failedCalls} inverse />}
-          icon={AlertTriangle}
-          loading={loading}
-          tone="danger"
-        />
-        <StatCard
-          label="Missed"
-          value={totals?.missedCalls.toLocaleString() ?? "0"}
-          helper={<Trend value={deltas?.missedCalls} inverse />}
-          icon={Voicemail}
-          loading={loading}
-          tone="warning"
-        />
+        <Link
+          href={dashboardCallsHref({ range, status: "FAILED" })}
+          className={drilldownLinkClass}
+          aria-label="Review failed calls in the selected dashboard range"
+        >
+          <StatCard
+            label="Failed"
+            value={totals?.failedCalls.toLocaleString() ?? "0"}
+            helper={
+              <InvestigationHint action="Review failed calls">
+                {deltas ? (
+                  <Trend
+                    value={deltas.failedCalls}
+                    unit="call"
+                    comparisonLabel={previousPeriodLabel}
+                    inverse
+                  />
+                ) : null}
+              </InvestigationHint>
+            }
+            icon={AlertTriangle}
+            loading={loading}
+            tone="danger"
+            className="h-full"
+          />
+        </Link>
+        <Link
+          href={dashboardCallsHref({ range, status: "NOT_ANSWERED" })}
+          className={drilldownLinkClass}
+          aria-label="View missed calls in the selected dashboard range"
+        >
+          <StatCard
+            label="Missed"
+            value={totals?.missedCalls.toLocaleString() ?? "0"}
+            helper={
+              <InvestigationHint action="View missed calls">
+                {deltas ? (
+                  <Trend
+                    value={deltas.missedCalls}
+                    unit="call"
+                    comparisonLabel={previousPeriodLabel}
+                    inverse
+                  />
+                ) : null}
+              </InvestigationHint>
+            }
+            icon={Voicemail}
+            loading={loading}
+            tone="warning"
+            className="h-full"
+          />
+        </Link>
       </div>
     </div>
   );

--- a/apps/console/src/components/dashboard/RangeSwitcher.tsx
+++ b/apps/console/src/components/dashboard/RangeSwitcher.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTransition } from "react";
+import { Loader2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   ToggleGroup,
@@ -13,35 +15,59 @@ const RANGES: { value: DashboardRange; label: string }[] = [
   { value: "30d", label: "30 days" },
 ];
 
-export function RangeSwitcher({ current }: { current: DashboardRange }) {
+export function RangeSwitcher({
+  current,
+  loading = false,
+}: {
+  current: DashboardRange;
+  loading?: boolean;
+}) {
   const router = useRouter();
   const pathname = usePathname();
   const params = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const busy = loading || isPending;
 
   function onChange(value: string) {
     if (!value) return;
     const next = new URLSearchParams(params);
     next.set("range", value);
-    router.replace(`${pathname}?${next.toString()}`);
+    startTransition(() => {
+      router.replace(`${pathname}?${next.toString()}`);
+    });
   }
 
   return (
-    <ToggleGroup
-      type="single"
-      size="sm"
-      value={current}
-      onValueChange={onChange}
-      className="border bg-background p-1"
-    >
-      {RANGES.map((range) => (
-        <ToggleGroupItem
-          key={range.value}
-          value={range.value}
-          className="h-8 px-3 text-xs font-semibold text-muted-foreground data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+    <div className="flex w-full flex-col gap-2 sm:w-auto sm:items-end">
+      <ToggleGroup
+        type="single"
+        size="sm"
+        value={current}
+        onValueChange={onChange}
+        aria-label="Dashboard date range"
+        aria-busy={busy}
+        className="w-full border bg-background p-1 sm:w-fit"
+      >
+        {RANGES.map((range) => (
+          <ToggleGroupItem
+            key={range.value}
+            value={range.value}
+            className="h-8 flex-1 px-3 text-xs font-semibold text-muted-foreground data-[state=on]:bg-primary data-[state=on]:text-primary-foreground sm:flex-none"
+          >
+            {range.label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+      {busy ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-center gap-1.5 text-xs text-muted-foreground"
         >
-          {range.label}
-        </ToggleGroupItem>
-      ))}
-    </ToggleGroup>
+          <Loader2 className="size-3 animate-spin" />
+          Updating dashboard range
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/console/src/components/dashboard/RecentCallsTable.tsx
+++ b/apps/console/src/components/dashboard/RecentCallsTable.tsx
@@ -1,12 +1,26 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, Clock3, PhoneCall } from "lucide-react";
+import { AlertTriangle, ArrowRight, PhoneCall } from "lucide-react";
 import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/src/components/ui/table";
 import { EmptyState } from "@/src/components/common/EmptyState";
 import type { DashboardSummary } from "@/src/lib/api/resources/dashboard";
-import type { CallStatus } from "@/src/lib/api/types";
+import { useAgents } from "@/src/hooks/queries/agents";
+import type { Agent, CallLog, CallStatus } from "@/src/lib/api/types";
+
+const linkFocusClass =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 function statusVariant(
   status: CallStatus
@@ -40,20 +54,24 @@ function statusClass(status: CallStatus) {
   }
 }
 
-function formatRelative(iso: string | null) {
-  if (!iso) return "No start time";
-  const d = new Date(iso);
-  const diff = Date.now() - d.getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
+function formatAbsoluteTimestamp(iso: string | null) {
+  if (!iso) return "No start timestamp";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "Invalid timestamp";
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  }).format(date);
 }
 
 function formatDuration(seconds: number | null) {
-  if (!seconds) return "0s";
+  if (seconds === null) return "Unknown";
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return m ? `${m}m ${s}s` : `${s}s`;
@@ -63,6 +81,64 @@ function formatStatus(status: string) {
   return status.toLowerCase().replace("_", " ");
 }
 
+function metadataText(call: CallLog, key: "fromNumber" | "toNumber") {
+  const value = call.metadata?.[key];
+  return typeof value === "string" && value.trim().length ? value : null;
+}
+
+function callParties(call: CallLog) {
+  const fromNumber = metadataText(call, "fromNumber");
+  const toNumber = metadataText(call, "toNumber");
+
+  if (call.direction === "inbound") {
+    return {
+      caller: fromNumber ?? call.callerId ?? "Unknown caller",
+      callee: toNumber ?? "Unknown callee",
+    };
+  }
+
+  if (call.direction === "outbound") {
+    return {
+      caller: fromNumber ?? "Unknown caller",
+      callee: toNumber ?? call.callerId ?? "Unknown callee",
+    };
+  }
+
+  return {
+    caller: fromNumber ?? call.callerId ?? "Unknown caller",
+    callee: toNumber ?? "Unknown callee",
+  };
+}
+
+function shortId(id: string) {
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+function resolveAgentLabel({
+  call,
+  agents,
+  agentsLoading,
+  agentsError,
+}: {
+  call: CallLog;
+  agents?: Agent[];
+  agentsLoading: boolean;
+  agentsError: boolean;
+}) {
+  if (!call.agentId) return "Unassigned";
+  if (agentsLoading) return "Resolving agent";
+  if (agentsError) return "Agent name unavailable";
+  return agents?.find((agent) => agent.agentId === call.agentId)?.name ?? "Unknown agent";
+}
+
+function CallTimestamp({ call }: { call: CallLog }) {
+  return call.startTime ? (
+    <time dateTime={call.startTime}>{formatAbsoluteTimestamp(call.startTime)}</time>
+  ) : (
+    <span>No start timestamp</span>
+  );
+}
+
 export function RecentCallsTable({
   summary,
   loading,
@@ -70,27 +146,49 @@ export function RecentCallsTable({
   summary?: DashboardSummary;
   loading?: boolean;
 }) {
+  const {
+    data: agents,
+    isLoading: agentsLoading,
+    isError: agentsError,
+  } = useAgents();
+  const hasAgentLookupGap =
+    agentsError && Boolean(summary?.recent.some((call) => call.agentId));
+
   return (
     <div className="border bg-card">
       <div className="flex items-center justify-between border-b px-5 py-4">
         <div>
           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Live log
+            Recent activity
           </p>
           <h3 className="mt-1 text-base font-semibold text-foreground">
-            Recent calls
+            Recent call logs
           </h3>
           <p className="text-xs text-muted-foreground">
-            Latest call activity across all agents.
+            Latest call log activity across all agents.
           </p>
         </div>
         <Link
           href="/calls"
-          className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+          className={`inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline ${linkFocusClass}`}
         >
-          View all <ArrowRight className="size-3" />
+          View call logs <ArrowRight className="size-3" />
         </Link>
       </div>
+      {hasAgentLookupGap ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-start gap-2 border-b border-amber-500/30 bg-amber-500/10 px-5 py-3 text-xs text-amber-800 dark:text-amber-200"
+        >
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+          <span>
+            <span className="font-semibold">Partial call log data:</span>{" "}
+            recent call logs loaded, but agent names could not be resolved. Open
+            a call detail for the full source record.
+          </span>
+        </div>
+      ) : null}
       {loading ? (
         <div className="space-y-2 p-5">
           {[...Array(6)].map((_, i) => (
@@ -100,51 +198,168 @@ export function RecentCallsTable({
       ) : !summary?.recent.length ? (
         <EmptyState
           icon={PhoneCall}
-          title="No calls yet"
-          description="Once your agents take calls, they'll show up here."
+          title="No call logs yet"
+          description="Start with a test call or connect a number so recent call log activity has source records to show."
           className="border-0"
+          action={
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button asChild size="sm">
+                <Link href="/outbound">Start with a test call</Link>
+              </Button>
+              <Button asChild size="sm" variant="outline">
+                <Link href="/numbers">Connect number</Link>
+              </Button>
+            </div>
+          }
         />
       ) : (
-        <div>
-          <div className="hidden grid-cols-[1fr_130px_140px_40px] border-b bg-muted/20 px-5 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground sm:grid">
-            <span>Caller</span>
-            <span className="text-right">Duration</span>
-            <span>Status</span>
-            <span />
-          </div>
-          <div className="divide-y">
-            {summary.recent.map((call) => (
-              <Link
-                key={call.callId}
-                href={`/calls/${call.callId}`}
-                className="group grid gap-3 px-5 py-3 transition-colors hover:bg-muted/40 sm:grid-cols-[1fr_130px_140px_40px] sm:items-center"
-              >
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-foreground">
-                    {call.callerId ?? "Unknown caller"}
-                  </p>
-                  <p className="truncate text-xs text-muted-foreground">
-                    {formatRelative(call.startTime)} / {call.direction ?? "unknown"}
-                  </p>
-                </div>
-                <div className="inline-flex items-center gap-2 text-xs text-muted-foreground sm:justify-end sm:text-right">
-                  <Clock3 className="size-3 sm:hidden" />
-                  <div>
-                    <p className="font-medium text-foreground">
-                      {formatDuration(call.durationSeconds)}
-                    </p>
-                    <p>duration</p>
-                  </div>
-                </div>
-                <Badge
-                  variant={statusVariant(call.status)}
-                  className={`w-fit shrink-0 capitalize ${statusClass(call.status)}`}
-                >
-                  {formatStatus(call.status)}
-                </Badge>
-                <ArrowRight className="hidden size-4 justify-self-end text-muted-foreground transition-transform group-hover:translate-x-0.5 sm:block" />
-              </Link>
-            ))}
+        <div className="divide-y md:divide-y-0">
+          <ul className="divide-y md:hidden">
+            {summary.recent.map((call) => {
+              const parties = callParties(call);
+              const agentLabel = resolveAgentLabel({
+                call,
+                agents,
+                agentsLoading,
+                agentsError,
+              });
+
+              return (
+                <li key={call.callId}>
+                  <Link
+                    href={`/calls/${call.callId}`}
+                    aria-label={`Open call ${call.callId}: ${parties.caller} to ${parties.callee}`}
+                    className={`group block px-5 py-4 transition-colors hover:bg-muted/40 ${linkFocusClass}`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium text-muted-foreground">
+                          <CallTimestamp call={call} />
+                        </p>
+                        <p className="mt-1 truncate text-sm font-semibold text-foreground">
+                          {parties.caller}
+                        </p>
+                      </div>
+                      <Badge
+                        variant={statusVariant(call.status)}
+                        className={`w-fit shrink-0 capitalize ${statusClass(call.status)}`}
+                      >
+                        {formatStatus(call.status)}
+                      </Badge>
+                    </div>
+                    <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                      <div>
+                        <dt className="text-muted-foreground">Callee</dt>
+                        <dd className="truncate font-medium text-foreground">
+                          {parties.callee}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Agent</dt>
+                        <dd className="truncate font-medium text-foreground">
+                          {agentLabel}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Duration</dt>
+                        <dd className="font-medium text-foreground">
+                          {formatDuration(call.durationSeconds)}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Direction</dt>
+                        <dd className="font-medium capitalize text-foreground">
+                          {call.direction ?? "unknown"}
+                        </dd>
+                      </div>
+                    </dl>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+
+          <div className="hidden md:block">
+            <Table className="min-w-[920px]">
+              <TableCaption className="sr-only">
+                Recent call logs with absolute timestamps, caller, callee,
+                assigned agent, duration, and status.
+              </TableCaption>
+              <TableHeader>
+                <TableRow className="border-b bg-muted/20 hover:bg-muted/20">
+                  <TableHead className="pl-5">Started</TableHead>
+                  <TableHead>Caller</TableHead>
+                  <TableHead>Callee</TableHead>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Duration</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="pr-5 text-right">Details</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {summary.recent.map((call) => {
+                  const parties = callParties(call);
+                  const agentLabel = resolveAgentLabel({
+                    call,
+                    agents,
+                    agentsLoading,
+                    agentsError,
+                  });
+
+                  return (
+                    <TableRow key={call.callId} className="hover:bg-muted/30">
+                      <TableCell className="pl-5 align-top text-sm text-muted-foreground">
+                        <CallTimestamp call={call} />
+                        <p className="mt-1 text-xs capitalize">
+                          {call.direction ?? "unknown"}
+                        </p>
+                      </TableCell>
+                      <TableCell className="max-w-[180px] whitespace-normal align-top">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {parties.caller}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">Caller</p>
+                      </TableCell>
+                      <TableCell className="max-w-[180px] whitespace-normal align-top">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {parties.callee}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">Callee</p>
+                      </TableCell>
+                      <TableCell className="max-w-[180px] whitespace-normal align-top">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {agentLabel}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {call.agentId ? `ID ${shortId(call.agentId)}` : "No agent assigned"}
+                        </p>
+                      </TableCell>
+                      <TableCell className="align-top text-sm">
+                        {formatDuration(call.durationSeconds)}
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <Badge
+                          variant={statusVariant(call.status)}
+                          className={`w-fit shrink-0 capitalize ${statusClass(call.status)}`}
+                        >
+                          {formatStatus(call.status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="pr-5 text-right align-top">
+                        <Link
+                          href={`/calls/${call.callId}`}
+                          aria-label={`Open call ${call.callId}: ${parties.caller} to ${parties.callee}`}
+                          className={`group inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline ${linkFocusClass}`}
+                        >
+                          Open
+                          <ArrowRight className="size-3 transition-transform group-hover:translate-x-0.5" />
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
           </div>
         </div>
       )}

--- a/apps/console/src/components/dashboard/VolumeChart.tsx
+++ b/apps/console/src/components/dashboard/VolumeChart.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import Link from "next/link";
+import { useId } from "react";
+import { PhoneCall } from "lucide-react";
 import {
   Area,
   Bar,
   CartesianGrid,
   ComposedChart,
   Line,
-  Legend,
   XAxis,
   YAxis,
 } from "recharts";
@@ -16,7 +18,9 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/src/components/ui/chart";
+import { Button } from "@/src/components/ui/button";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import { EmptyState } from "@/src/components/common/EmptyState";
 import type {
   DashboardRange,
   DashboardSeriesPoint,
@@ -53,6 +57,10 @@ export function VolumeChart({
   range: DashboardRange;
   loading?: boolean;
 }) {
+  const titleId = useId();
+  const summaryId = useId();
+  const bucketUnit = range === "24h" ? "hour" : "day";
+
   if (loading) {
     return (
       <div className="border bg-card p-5">
@@ -74,17 +82,21 @@ export function VolumeChart({
   const minutes = totalFor(data, "minutes");
 
   return (
-    <div className="border bg-card">
+    <div className="border bg-card" aria-labelledby={titleId}>
       <div className="flex flex-col gap-4 border-b p-5 xl:flex-row xl:items-end xl:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Traffic timeline
           </p>
-          <h3 className="mt-1 text-lg font-semibold tracking-tight text-foreground">
+          <h3
+            id={titleId}
+            className="mt-1 text-lg font-semibold tracking-tight text-foreground"
+          >
             Calls, minutes, and outcome pressure
           </h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Bucketed by {range === "24h" ? "hour" : "day"} with failures overlaid.
+          <p id={summaryId} className="mt-1 text-sm text-muted-foreground">
+            Bucketed by {bucketUnit}. X-axis shows {bucketUnit}; left axis shows
+            calls and failed calls; right axis shows minutes.
           </p>
         </div>
         <div className="grid grid-cols-3 border bg-background text-center text-xs sm:min-w-96">
@@ -103,94 +115,186 @@ export function VolumeChart({
         </div>
       </div>
       {data.length === 0 ? (
-        <div className="m-5 flex h-80 items-center justify-center border border-dashed text-sm text-muted-foreground">
-          No calls yet in this range.
-        </div>
+        <EmptyState
+          icon={PhoneCall}
+          title="No calls yet in this range"
+          description="Place a test call or connect a number to start building the traffic timeline."
+          className="m-5 h-80 bg-background/40"
+          action={
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button asChild size="sm">
+                <Link href="/outbound">Place a test call</Link>
+              </Button>
+              <Button asChild size="sm" variant="outline">
+                <Link href="/numbers">Connect number</Link>
+              </Button>
+            </div>
+          }
+        />
       ) : (
-        <ChartContainer config={config} className="h-[22rem] w-full p-5">
-          <ComposedChart
-            data={data}
-            margin={{ top: 4, right: 16, left: 0, bottom: 0 }}
+        <>
+          <ChartContainer
+            config={config}
+            className="h-[22rem] w-full p-5"
+            role="group"
+            aria-label="Traffic timeline chart"
           >
-            <defs>
-              <linearGradient
-                id="dashboard-minutes-fill"
-                x1="0"
-                y1="0"
-                x2="0"
-                y2="1"
-              >
-                <stop
-                  offset="0%"
-                  stopColor="var(--color-minutes)"
-                  stopOpacity={0.34}
-                />
-                <stop
-                  offset="100%"
-                  stopColor="var(--color-minutes)"
-                  stopOpacity={0.02}
-                />
-              </linearGradient>
-            </defs>
-            <CartesianGrid
-              strokeDasharray="3 3"
-              className="stroke-border"
-              vertical={false}
-            />
-            <XAxis
-              dataKey="t"
-              tickFormatter={(v) => formatTick(v, range)}
-              stroke="currentColor"
-              className="text-xs text-muted-foreground"
-              tickLine={false}
-              axisLine={false}
-            />
-            <YAxis
-              yAxisId="left"
-              stroke="currentColor"
-              className="text-xs text-muted-foreground"
-              tickLine={false}
-              axisLine={false}
-              width={32}
-            />
-            <YAxis yAxisId="right" orientation="right" hide />
-            <ChartTooltip
-              content={
-                <ChartTooltipContent
-                  labelFormatter={(v) => formatTick(String(v), range)}
-                />
-              }
-            />
-            <Legend
-              verticalAlign="top"
-              height={32}
-              iconType="square"
-              wrapperStyle={{ color: "var(--muted-foreground)", fontSize: 12 }}
-            />
-            <Area
-              yAxisId="right"
-              type="monotone"
-              dataKey="minutes"
-              stroke="var(--color-minutes)"
-              strokeWidth={2}
-              fill="url(#dashboard-minutes-fill)"
-            />
-            <Bar
-              yAxisId="left"
-              dataKey="calls"
-              fill="var(--color-calls)"
-              barSize={16}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="failed"
-              stroke="var(--color-failed)"
-              strokeWidth={2}
-              dot={false}
-            />
-          </ComposedChart>
-        </ChartContainer>
+            <ComposedChart
+              accessibilityLayer
+              data={data}
+              margin={{ top: 12, right: 44, left: 18, bottom: 28 }}
+              aria-label="Calls, minutes, and failed calls over time"
+              aria-describedby={summaryId}
+            >
+              <defs>
+                <linearGradient
+                  id="dashboard-minutes-fill"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop
+                    offset="0%"
+                    stopColor="var(--color-minutes)"
+                    stopOpacity={0.34}
+                  />
+                  <stop
+                    offset="100%"
+                    stopColor="var(--color-minutes)"
+                    stopOpacity={0.02}
+                  />
+                </linearGradient>
+              </defs>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                className="stroke-border"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="t"
+                tickFormatter={(v) => formatTick(v, range)}
+                stroke="currentColor"
+                className="text-xs text-muted-foreground"
+                tickLine={false}
+                axisLine={false}
+                label={{
+                  value: bucketUnit === "hour" ? "Hour" : "Day",
+                  position: "insideBottom",
+                  offset: -18,
+                }}
+              />
+              <YAxis
+                yAxisId="left"
+                stroke="currentColor"
+                className="text-xs text-muted-foreground"
+                tickLine={false}
+                axisLine={false}
+                width={42}
+                label={{
+                  value: `Calls by ${bucketUnit}`,
+                  angle: -90,
+                  position: "insideLeft",
+                }}
+              />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                stroke="currentColor"
+                className="text-xs text-muted-foreground"
+                tickLine={false}
+                axisLine={false}
+                width={48}
+                label={{
+                  value: "Minutes (right axis)",
+                  angle: 90,
+                  position: "insideRight",
+                }}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(v) => formatTick(String(v), range)}
+                  />
+                }
+              />
+              <Area
+                yAxisId="right"
+                type="monotone"
+                dataKey="minutes"
+                name="Minutes (right axis)"
+                stroke="var(--color-minutes)"
+                strokeWidth={2}
+                fill="url(#dashboard-minutes-fill)"
+              />
+              <Bar
+                yAxisId="left"
+                dataKey="calls"
+                name={`Calls by ${bucketUnit}`}
+                fill="var(--color-calls)"
+                barSize={16}
+              />
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="failed"
+                name="Failed calls"
+                stroke="var(--color-failed)"
+                strokeWidth={2}
+                dot={false}
+              />
+            </ComposedChart>
+          </ChartContainer>
+          <ul
+            className="grid gap-2 px-5 pb-5 text-xs text-muted-foreground sm:grid-cols-3"
+            aria-label="Traffic timeline legend"
+          >
+            <li className="flex items-center gap-2">
+              <span
+                aria-hidden
+                className="h-4 w-2 border border-primary bg-primary"
+              />
+              <span>Calls by {bucketUnit} - bar series</span>
+            </li>
+            <li className="flex items-center gap-2">
+              <span
+                aria-hidden
+                className="h-3 w-5 border border-emerald-500 bg-emerald-500/20"
+              />
+              <span>Minutes (right axis) - shaded area</span>
+            </li>
+            <li className="flex items-center gap-2">
+              <span
+                aria-hidden
+                className="h-px w-6 border-t-2 border-destructive"
+              />
+              <span>Failed calls - line series</span>
+            </li>
+          </ul>
+          <div className="sr-only">
+            <table aria-describedby={summaryId}>
+              <caption>Traffic timeline data table</caption>
+              <thead>
+                <tr>
+                  <th scope="col">{bucketUnit}</th>
+                  <th scope="col">Calls</th>
+                  <th scope="col">Minutes</th>
+                  <th scope="col">Failed calls</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((point) => (
+                  <tr key={point.t}>
+                    <th scope="row">{formatTick(point.t, range)}</th>
+                    <td>{point.calls}</td>
+                    <td>{point.minutes}</td>
+                    <td>{point.failed}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </div>
   );

--- a/apps/console/src/components/dashboard/call-filter-links.ts
+++ b/apps/console/src/components/dashboard/call-filter-links.ts
@@ -1,0 +1,19 @@
+import type { CallStatus } from "@/src/lib/api/types";
+import type { DashboardRange } from "@/src/lib/api/resources/dashboard";
+
+export function dashboardCallsHref({
+  range,
+  status,
+  agentId,
+}: {
+  range: DashboardRange;
+  status?: CallStatus;
+  agentId?: string | null;
+}) {
+  const params = new URLSearchParams();
+  params.set("range", range);
+  if (status) params.set("status", status);
+  if (agentId) params.set("agentId", agentId);
+
+  return `/calls?${params.toString()}`;
+}

--- a/apps/console/src/components/ui/skeleton.tsx
+++ b/apps/console/src/components/ui/skeleton.tsx
@@ -4,7 +4,8 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
  return (
  <div
  data-slot="skeleton"
- className={cn("animate-pulse bg-muted", className)}
+ aria-hidden="true"
+ className={cn("bg-muted motion-safe:animate-pulse", className)}
  {...props}
  />
  )

--- a/apps/console/src/lib/api-error-state.ts
+++ b/apps/console/src/lib/api-error-state.ts
@@ -1,0 +1,267 @@
+export type ApiErrorStateKind = "permission" | "offline" | "error";
+
+export type ApiErrorStateReason =
+  | "unauthorized"
+  | "forbidden"
+  | "offline"
+  | "server"
+  | "unknown";
+
+export type ApiErrorStateCopy = {
+  kind: ApiErrorStateKind;
+  reason: ApiErrorStateReason;
+  title: string;
+  description: string;
+  status?: number;
+  code?: string;
+};
+
+export type ApiErrorStateCopyOptions = {
+  resourceName: string;
+  isOnline?: boolean;
+  overrides?: Partial<
+    Record<
+      ApiErrorStateReason,
+      Partial<Pick<ApiErrorStateCopy, "title" | "description">>
+    >
+  >;
+};
+
+const AUTH_CODES = new Set([
+  "AUTH_REQUIRED",
+  "AUTHENTICATION_REQUIRED",
+  "SESSION_EXPIRED",
+  "TOKEN_EXPIRED",
+  "UNAUTHENTICATED",
+  "UNAUTHORIZED",
+]);
+
+const FORBIDDEN_CODES = new Set([
+  "ACCESS_DENIED",
+  "FORBIDDEN",
+  "INSUFFICIENT_PERMISSIONS",
+  "PERMISSION_DENIED",
+]);
+
+const NETWORK_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ERR_NETWORK",
+  "FETCH_FAILED",
+  "NETWORK_ERROR",
+  "OFFLINE",
+  "REQUEST_TIMEOUT",
+  "TIMEOUT",
+]);
+
+const NETWORK_MESSAGE_PATTERNS = [
+  /failed to fetch/i,
+  /internet connection appears to be offline/i,
+  /load failed/i,
+  /network ?error/i,
+  /network request failed/i,
+];
+
+const SERVER_CODES = new Set([
+  "BAD_GATEWAY",
+  "GATEWAY_TIMEOUT",
+  "INTERNAL_SERVER_ERROR",
+  "SERVICE_UNAVAILABLE",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function numberProperty(value: Record<string, unknown>, key: string) {
+  return typeof value[key] === "number" ? value[key] : undefined;
+}
+
+export function apiErrorStatus(error: unknown) {
+  if (!isRecord(error)) return undefined;
+
+  const directStatus = numberProperty(error, "status");
+  if (directStatus !== undefined) return directStatus;
+
+  const statusCode = numberProperty(error, "statusCode");
+  if (statusCode !== undefined) return statusCode;
+
+  const response = error.response;
+  if (isRecord(response)) return numberProperty(response, "status");
+
+  return undefined;
+}
+
+function stringProperty(value: Record<string, unknown>, key: string) {
+  return typeof value[key] === "string" ? value[key] : undefined;
+}
+
+export function apiErrorCode(error: unknown) {
+  if (!isRecord(error)) return undefined;
+
+  const directCode = stringProperty(error, "code");
+  if (directCode) return directCode;
+
+  const response = error.response;
+  if (!isRecord(response)) return undefined;
+
+  const data = response.data;
+  if (!isRecord(data)) return undefined;
+
+  const envelopeError = data.error;
+  if (isRecord(envelopeError)) return stringProperty(envelopeError, "code");
+
+  return stringProperty(data, "code");
+}
+
+function apiErrorMessage(error: unknown) {
+  if (!isRecord(error)) return undefined;
+
+  const directMessage = stringProperty(error, "message");
+  if (directMessage) return directMessage;
+
+  const response = error.response;
+  if (!isRecord(response)) return undefined;
+
+  const data = response.data;
+  if (!isRecord(data)) return undefined;
+
+  const envelopeError = data.error;
+  if (isRecord(envelopeError)) {
+    const envelopeMessage = stringProperty(envelopeError, "message");
+    if (envelopeMessage) return envelopeMessage;
+  }
+
+  return stringProperty(data, "message");
+}
+
+function normalizeCode(code?: string) {
+  return code?.trim().toUpperCase().replace(/[^A-Z0-9]+/g, "_") || undefined;
+}
+
+function matchesCode(code: string | undefined, values: Set<string>) {
+  if (!code) return false;
+  if (values.has(code)) return true;
+
+  return Array.from(values).some((value) => code.includes(value));
+}
+
+function matchesNetworkMessage(message: string | undefined) {
+  return Boolean(
+    message && NETWORK_MESSAGE_PATTERNS.some((pattern) => pattern.test(message))
+  );
+}
+
+function resourceLabel(resourceName: string) {
+  return resourceName.trim() || "workspace data";
+}
+
+function titleResource(resourceName: string) {
+  const resource = resourceLabel(resourceName);
+  return `${resource.charAt(0).toUpperCase()}${resource.slice(1)}`;
+}
+
+function withOverride(
+  copy: ApiErrorStateCopy,
+  overrides: ApiErrorStateCopyOptions["overrides"]
+) {
+  const override = overrides?.[copy.reason];
+  return override ? { ...copy, ...override } : copy;
+}
+
+function errorMetadata(
+  status: number | undefined,
+  code: string | undefined
+): Pick<ApiErrorStateCopy, "status" | "code"> {
+  const metadata: Pick<ApiErrorStateCopy, "status" | "code"> = {};
+  if (status !== undefined) metadata.status = status;
+  if (code !== undefined) metadata.code = code;
+  return metadata;
+}
+
+export function getApiErrorStateCopy(
+  error: unknown,
+  options: ApiErrorStateCopyOptions
+): ApiErrorStateCopy {
+  const status = apiErrorStatus(error);
+  const code = normalizeCode(apiErrorCode(error));
+  const message = apiErrorMessage(error);
+  const resource = resourceLabel(options.resourceName);
+  const titledResource = titleResource(resource);
+  const base = errorMetadata(status, code);
+
+  if (status === 401 || matchesCode(code, AUTH_CODES)) {
+    return withOverride(
+      {
+        ...base,
+        kind: "permission",
+        reason: "unauthorized",
+        title: `Sign in to load ${resource}`,
+        description: `Your QuickVoice session expired or the API rejected authentication. Sign in again, then retry loading ${resource}.`,
+      },
+      options.overrides
+    );
+  }
+
+  if (status === 403 || matchesCode(code, FORBIDDEN_CODES)) {
+    return withOverride(
+      {
+        ...base,
+        kind: "permission",
+        reason: "forbidden",
+        title: `${titledResource} access required`,
+        description: `Your current role does not include permission to load ${resource}. Ask a workspace owner to update your role or switch organizations.`,
+      },
+      options.overrides
+    );
+  }
+
+  if (
+    options.isOnline === false ||
+    status === 0 ||
+    matchesCode(code, NETWORK_CODES) ||
+    matchesNetworkMessage(message)
+  ) {
+    return withOverride(
+      {
+        ...base,
+        kind: "offline",
+        reason: "offline",
+        title: `${titledResource} unavailable offline`,
+        description: `Reconnect to the internet, then retry loading ${resource}. If cached data is available, QuickVoice will keep it visible while you reconnect.`,
+      },
+      options.overrides
+    );
+  }
+
+  if (
+    (typeof status === "number" && status >= 500) ||
+    matchesCode(code, SERVER_CODES)
+  ) {
+    return withOverride(
+      {
+        ...base,
+        kind: "error",
+        reason: "server",
+        title: "QuickVoice service unavailable",
+        description: `The API returned a server error while loading ${resource}. Retry in a moment; this is not caused by your browser connection.`,
+      },
+      options.overrides
+    );
+  }
+
+  return withOverride(
+    {
+      ...base,
+      kind: "error",
+      reason: "unknown",
+      title: `Could not load ${resource}`,
+      description: `Retry loading ${resource}. If the problem continues, share the issue with support.`,
+    },
+    options.overrides
+  );
+}

--- a/apps/console/tests/api-error-state.test.mjs
+++ b/apps/console/tests/api-error-state.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+import ts from "typescript";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const require = createRequire(import.meta.url);
+
+function loadApiErrorStateModule() {
+  const source = readFileSync(join(root, "src/lib/api-error-state.ts"), "utf8");
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const cjsModule = { exports: {} };
+
+  vm.runInNewContext(compiled, {
+    exports: cjsModule.exports,
+    module: cjsModule,
+    require,
+  });
+
+  return cjsModule.exports;
+}
+
+test("api error state copy distinguishes auth, permission, offline, server, and unknown failures", () => {
+  const { getApiErrorStateCopy } = loadApiErrorStateModule();
+
+  const unauthorized = getApiErrorStateCopy(
+    { status: 401, code: "UNAUTHORIZED" },
+    { resourceName: "call logs" }
+  );
+  assert.equal(unauthorized.kind, "permission");
+  assert.equal(unauthorized.reason, "unauthorized");
+  assert.equal(unauthorized.title, "Sign in to load call logs");
+  assert.match(unauthorized.description, /session/i);
+
+  const forbidden = getApiErrorStateCopy(
+    { status: 403, code: "FORBIDDEN" },
+    { resourceName: "dashboard" }
+  );
+  assert.equal(forbidden.kind, "permission");
+  assert.equal(forbidden.reason, "forbidden");
+  assert.equal(forbidden.title, "Dashboard access required");
+  assert.match(forbidden.description, /role/i);
+
+  const offlineByStatus = getApiErrorStateCopy(
+    { status: 0 },
+    { resourceName: "phone numbers", isOnline: true }
+  );
+  assert.equal(offlineByStatus.kind, "offline");
+  assert.equal(offlineByStatus.reason, "offline");
+  assert.equal(offlineByStatus.title, "Phone numbers unavailable offline");
+
+  const offlineByCode = getApiErrorStateCopy(
+    { code: "ERR_NETWORK" },
+    { resourceName: "knowledge base", isOnline: true }
+  );
+  assert.equal(offlineByCode.kind, "offline");
+  assert.match(offlineByCode.description, /Reconnect/i);
+
+  const offlineByFetchMessage = getApiErrorStateCopy(
+    new TypeError("Failed to fetch"),
+    { resourceName: "agents", isOnline: true }
+  );
+  assert.equal(offlineByFetchMessage.kind, "offline");
+  assert.equal(offlineByFetchMessage.reason, "offline");
+  assert.equal(offlineByFetchMessage.title, "Agents unavailable offline");
+
+  const server = getApiErrorStateCopy(
+    { status: 503, code: "SERVICE_UNAVAILABLE" },
+    { resourceName: "agents" }
+  );
+  assert.equal(server.kind, "error");
+  assert.equal(server.reason, "server");
+  assert.equal(server.title, "QuickVoice service unavailable");
+  assert.match(server.description, /server error/i);
+  assert.doesNotMatch(server.description, /checking your connection/i);
+
+  const unknown = getApiErrorStateCopy(
+    new Error("boom"),
+    { resourceName: "call detail" }
+  );
+  assert.equal(unknown.kind, "error");
+  assert.equal(unknown.reason, "unknown");
+  assert.equal(unknown.title, "Could not load call detail");
+  assert.doesNotMatch(unknown.description, /checking your connection/i);
+});

--- a/apps/console/tests/dashboard-audit-fixes.test.mjs
+++ b/apps/console/tests/dashboard-audit-fixes.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+test("dashboard exposes freshness, reporting window, and stale/offline state", () => {
+  const page = read("src/app/(app)/dashboard/page.tsx");
+  const freshness = read("src/components/dashboard/DashboardFreshness.tsx");
+
+  assert.match(page, /DashboardFreshness/);
+  assert.match(page, /dataUpdatedAt/);
+  assert.match(page, /isStale/);
+  assert.match(page, /isFetching/);
+
+  assert.match(freshness, /Reporting window/);
+  assert.match(freshness, /Last updated/);
+  assert.match(freshness, /Refresh dashboard/);
+  assert.match(freshness, /aria-busy=\{isFetching\}/);
+  assert.match(freshness, /navigator\.onLine/);
+  assert.match(freshness, /You are offline/);
+  assert.match(freshness, /Dashboard data is stale/);
+  assert.match(freshness, /summary\.period\.from/);
+  assert.match(freshness, /summary\.period\.to/);
+});
+
+test("dashboard KPI deltas use unit-aware copy and a named previous period", () => {
+  const source = read("src/components/dashboard/KpiCards.tsx");
+
+  assert.doesNotMatch(source, /suffix = "%"/);
+  assert.doesNotMatch(source, /vs previous/);
+  assert.match(source, /formatPreviousPeriodLabel/);
+  assert.match(source, /previousPeriodLabel/);
+  assert.match(source, /summary\.period\.previousFrom/);
+  assert.match(source, /summary\.period\.previousTo/);
+  assert.match(source, /unit="call"/);
+  assert.match(source, /unit="minute"/);
+  assert.match(source, /unit="second"/);
+  assert.match(source, /unit="percentage point"/);
+  assert.match(source, /comparisonLabel=\{previousPeriodLabel\}/);
+});
+
+test("dashboard exception signals link to filtered calls views with range context", () => {
+  const page = read("src/app/(app)/dashboard/page.tsx");
+  const kpis = read("src/components/dashboard/KpiCards.tsx");
+  const breakdown = read("src/components/dashboard/BreakdownCharts.tsx");
+  const agents = read("src/components/dashboard/AgentActivityList.tsx");
+  const helperPath = "src/components/dashboard/call-filter-links.ts";
+
+  assert.ok(
+    existsSync(join(root, helperPath)),
+    "dashboard call filter link helper should exist"
+  );
+  const helper = read(helperPath);
+
+  assert.match(helper, /new URLSearchParams/);
+  assert.match(helper, /params\.set\("range", range\)/);
+  assert.match(helper, /params\.set\("status", status\)/);
+  assert.match(helper, /params\.set\("agentId", agentId\)/);
+  assert.match(helper, /return `\/calls\?\$\{params\.toString\(\)\}`/);
+
+  assert.match(page, /<KpiCards[\s\S]*range=\{range\}/);
+  assert.match(page, /<AgentActivityList[\s\S]*range=\{range\}/);
+  assert.match(page, /<BreakdownCharts[\s\S]*range=\{range\}/);
+
+  assert.match(kpis, /dashboardCallsHref/);
+  assert.match(kpis, /status:\s*"FAILED"/);
+  assert.match(kpis, /status:\s*"NOT_ANSWERED"/);
+  assert.match(kpis, /Review failed calls/);
+  assert.match(kpis, /View missed calls/);
+
+  assert.match(breakdown, /dashboardCallsHref/);
+  assert.match(breakdown, /status:\s*item\.status/);
+  assert.match(breakdown, /Review/);
+
+  assert.match(agents, /dashboardCallsHref/);
+  assert.match(agents, /agentId:\s*agent\.agentId/);
+  assert.match(agents, /View calls/);
+});
+
+test("dashboard charts expose accessible summaries, unit labels, and data tables", () => {
+  const volume = read("src/components/dashboard/VolumeChart.tsx");
+  const breakdown = read("src/components/dashboard/BreakdownCharts.tsx");
+
+  for (const source of [volume, breakdown]) {
+    assert.match(source, /accessibilityLayer/);
+    assert.match(source, /aria-label=/);
+    assert.match(source, /<table/);
+    assert.match(source, /<caption/);
+    assert.match(source, /<thead/);
+    assert.match(source, /<tbody/);
+    assert.match(source, /sr-only/);
+  }
+
+  assert.match(volume, /Calls by/);
+  assert.match(volume, /Minutes \(right axis\)/);
+  assert.match(volume, /Failed calls/);
+  assert.match(volume, /aria-describedby=\{summaryId\}/);
+
+  assert.match(breakdown, /aria-label="Call outcome status breakdown chart"/);
+  assert.match(breakdown, /aria-label="Inbound and outbound direction mix chart"/);
+  assert.match(breakdown, /statusPattern/);
+  assert.match(breakdown, /directionPattern/);
+  assert.match(breakdown, /Percentage of routed calls/);
+});
+
+test("dashboard range switching is labelled, responsive, and exposes loading state", () => {
+  const page = read("src/app/(app)/dashboard/page.tsx");
+  const source = read("src/components/dashboard/RangeSwitcher.tsx");
+
+  assert.match(page, /<RangeSwitcher current=\{range\} loading=\{isFetching\}/);
+  assert.match(source, /aria-label="Dashboard date range"/);
+  assert.match(source, /aria-busy=\{busy\}/);
+  assert.match(source, /role="status"/);
+  assert.match(source, /aria-live="polite"/);
+  assert.match(source, /Updating dashboard range/);
+  assert.match(source, /w-full[^"]*sm:w-auto/);
+  assert.match(source, /flex-1[^"]*sm:flex-none/);
+});
+
+test("dashboard recent calls use semantic table and list context", () => {
+  const source = read("src/components/dashboard/RecentCallsTable.tsx");
+
+  assert.match(source, /useAgents/);
+  assert.match(source, /<Table/);
+  assert.match(source, /<TableCaption/);
+  assert.match(source, /<TableHeader/);
+  assert.match(source, /<TableBody/);
+  assert.match(source, /<ul/);
+  assert.match(source, /<li/);
+
+  assert.match(source, /formatAbsoluteTimestamp/);
+  assert.match(source, /<time[\s\S]*dateTime=\{call\.startTime\}/);
+  assert.doesNotMatch(source, /formatRelative/);
+
+  assert.match(source, /caller/);
+  assert.match(source, /callee/);
+  assert.match(source, /agentLabel/);
+  assert.match(source, /Agent name unavailable/);
+
+  assert.match(source, /aria-label=\{`Open call \$\{call\.callId\}/);
+  assert.match(source, /focus-visible:ring-2/);
+  assert.match(source, /focus-visible:ring-offset-2/);
+});
+
+test("dashboard agent activity distinguishes agent lookup state from unassigned calls", () => {
+  const source = read("src/components/dashboard/AgentActivityList.tsx");
+
+  assert.match(source, /isLoading:\s*agentsLoading/);
+  assert.match(source, /isError:\s*agentsError/);
+  assert.match(source, /if \(!agent\.agentId\) return "Unassigned"/);
+  assert.match(source, /if \(agentsLoading\) return "Resolving agent"/);
+  assert.match(source, /if \(agentsError\) return "Agent name unavailable"/);
+  assert.match(source, /Unknown agent/);
+  assert.doesNotMatch(
+    source,
+    /agents\?\.find\(\(agent\) => agent\.agentId === id\)\?\.name \?\? "Unassigned"/
+  );
+});
+
+test("dashboard empty and failure states cover permission, offline, partial data, and setup guidance", () => {
+  const page = read("src/app/(app)/dashboard/page.tsx");
+  const volume = read("src/components/dashboard/VolumeChart.tsx");
+  const breakdown = read("src/components/dashboard/BreakdownCharts.tsx");
+  const agents = read("src/components/dashboard/AgentActivityList.tsx");
+  const recent = read("src/components/dashboard/RecentCallsTable.tsx");
+
+  assert.match(page, /PermissionState/);
+  assert.match(page, /OfflineState/);
+  assert.match(page, /isPermissionError/);
+  assert.match(page, /status === 403/);
+  assert.match(page, /navigator\.onLine/);
+  assert.match(page, /Partial dashboard data/);
+  assert.match(page, /getMissingDashboardSections/);
+  assert.match(page, /Review call logs/);
+
+  assert.match(volume, /No calls yet in this range/);
+  assert.match(volume, /Place a test call/);
+  assert.match(volume, /Connect number/);
+
+  assert.match(breakdown, /No outcomes yet/);
+  assert.match(breakdown, /No routing data yet/);
+  assert.match(breakdown, /Place a test call/);
+  assert.match(breakdown, /Connect a number/);
+
+  assert.match(agents, /Partial agent data/);
+  assert.match(agents, /Create agent/);
+  assert.match(agents, /Connect number/);
+
+  assert.match(recent, /Partial call log data/);
+  assert.match(recent, /Start with a test call/);
+  assert.match(recent, /Connect number/);
+});

--- a/scripts/ci-docker-build.sh
+++ b/scripts/ci-docker-build.sh
@@ -10,7 +10,8 @@ docker buildx build \
 
 docker buildx build \
   --file apps/ai/Dockerfile \
-  --build-arg SKIP_MODEL_DOWNLOAD=1 \
+  --build-arg PREINSTALL_CPU_TORCH=true \
+  --build-arg SKIP_MODEL_DOWNLOAD=true \
   --tag quickvoice-ai:ci \
   --load \
   apps/ai


### PR DESCRIPTION
## Summary
- Add dashboard freshness/reporting-window visibility, stale/offline states, and refresh handling.
- Improve KPI delta copy, exception drilldowns, chart accessibility, recent-calls semantics, and agent lookup states.
- Add shared retry/API error-state helpers plus focused dashboard audit regression tests.
- Fix CI AI Docker validation to use CPU-only Torch and actually skip model downloads during CI image checks.

## Local verification
- `node --test apps/console/tests/dashboard-audit-fixes.test.mjs`
- `node --test apps/console/tests/api-error-state.test.mjs`
- `pnpm --filter console check-types`
- `pnpm --filter console lint`
- `pnpm ci:local` passed lint/typecheck/build/root tests/server tests/AI Python tests before Docker validation.
- `pnpm ci:docker` passed after the CI Docker fix, loading `quickvoice-server:ci` and `quickvoice-ai:ci` locally.