### PR TITLE
[codex] fix AI image vulnerability scan

### DIFF
--- a/apps/ai/Dockerfile
+++ b/apps/ai/Dockerfile
@@ -33,9 +33,12 @@ RUN adduser \
 # g++: C++ compiler needed for building Python packages with C++ extensions
 # python3-dev: Python development headers needed for compilation
 # We clean up the apt cache after installation to keep the image size down
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
+    linux-libc-dev \
     python3-dev \
   && rm -rf /var/lib/apt/lists/*
 
@@ -51,6 +54,7 @@ COPY requirements.txt ./
 ARG PREINSTALL_CPU_TORCH=false
 RUN if [ "$PREINSTALL_CPU_TORCH" = "true" ]; then \
       pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu; \
+      pip install --no-cache-dir "setuptools>=78.1.1,<82"; \
     fi \
   && pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- Upgrade Debian packages during the AI image build and explicitly install the fixed linux-libc-dev package pulled in by Python build deps.
- Keep the CI CPU Torch validation path while upgrading setuptools to a patched version that still satisfies Torch's <82 constraint.

## Verification
- git diff --check
- bash -n scripts/ci-docker-build.sh
- pnpm ci:docker
- docker run --rm quickvoice-ai:ci sh -lc 'dpkg-query -W linux-libc-dev && python - <<"PY"\nimport importlib.metadata as m\nfor name in ("setuptools", "torch"):\n    print(f"{name} {m.version(name)}")\nPY'\n- docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.69.3 image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 quickvoice-ai:ci