### PR TITLE
feat(ai): trace voice agent with Langfuse via LiveKit OpenTelemetry

### DIFF
--- a/apps/ai/.env.dev.example
+++ b/apps/ai/.env.dev.example
@@ -49,3 +49,9 @@ S3_BUCKET_NAME=quickvoice-dev
 ACCESS_KEY=dev-s3-access-key
 SECRET_ACCESS_KEY=dev-s3-secret-access-key
 REGION=us-east-1
+
+# --- Langfuse (LLM observability / evaluation) ---
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_HOST=https://cloud.langfuse.com
+LANGFUSE_TRACING_ENABLED=true

--- a/apps/ai/main.py
+++ b/apps/ai/main.py
@@ -41,6 +41,7 @@ from handlers.voice_provider_adapters import ProviderAdapterError, build_voice_p
 from handlers.voice_worker_metadata import is_voice_session_metadata, parse_voice_session_metadata
 from utils.logger import logger
 from utils.logger import redact_sensitive
+from utils.telemetry import setup_langfuse_tracing
 import asyncio
 import json
 from datetime import datetime, timezone
@@ -438,6 +439,21 @@ async def entrypoint(ctx: JobContext):
     logger.info("Entrypoint called with room: {}", redact_sensitive(ctx.room.name))
 
     await ctx.connect()
+
+    # --- Langfuse tracing: wire LiveKit's OpenTelemetry tracer to Langfuse ---
+    langfuse_trace_provider = setup_langfuse_tracing(
+        metadata={"langfuse.session.id": ctx.room.name},
+    )
+    if langfuse_trace_provider is not None and hasattr(ctx, "add_shutdown_callback"):
+        async def _flush_langfuse_trace():
+            try:
+                langfuse_trace_provider.force_flush()
+            except Exception as error:  # noqa: BLE001
+                logger.warning("[langfuse] trace flush failed: {}", redact_sensitive(str(error)))
+
+        ctx.add_shutdown_callback(_flush_langfuse_trace)
+    # --- end Langfuse tracing ---
+
     raw_metadata = ctx.job.metadata or ""
     if is_voice_session_metadata(raw_metadata):
         voice_metadata = parse_voice_session_metadata(raw_metadata)

--- a/apps/ai/requirements.txt
+++ b/apps/ai/requirements.txt
@@ -20,3 +20,6 @@ xlrd>=2.0,<3
 httpx>=0.27,<1
 beautifulsoup4>=4.12,<5
 redis>=5,<7
+# --- Langfuse LLM observability / evaluation (added) ---
+langfuse~=3.0
+opentelemetry-sdk>=1.29,<2

--- a/apps/ai/scripts/langfuse_smoke.py
+++ b/apps/ai/scripts/langfuse_smoke.py
@@ -1,0 +1,104 @@
+"""
+Langfuse connectivity smoke test for the QuickVoice AI voice agent.
+
+Sends exactly one trace to Langfuse using the same env vars the agent reads, so
+you can confirm credentials / host / network work WITHOUT spinning up LiveKit or
+placing a call. Run it after filling in apps/ai/.env.dev (or .env):
+
+    cd apps/ai && .venv/Scripts/python scripts/langfuse_smoke.py   # Windows
+    cd apps/ai && .venv/bin/python scripts/langfuse_smoke.py       # macOS/Linux
+
+Exits non-zero if authentication fails.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+APP_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_env() -> None:
+    # Load .env.dev first, then .env. load_dotenv does not override values that
+    # are already set, so whichever is loaded first wins -- matching how the
+    # agent layers its dev config on top of the base file.
+    for name in (".env.dev", ".env"):
+        path = APP_DIR / name
+        if path.exists():
+            load_dotenv(path)
+            print(f"[smoke] loaded {path}")
+
+
+def main() -> int:
+    _load_env()
+
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY", "").strip()
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY", "").strip()
+    host = (
+        os.getenv("LANGFUSE_HOST")
+        or os.getenv("LANGFUSE_BASE_URL")
+        or "https://cloud.langfuse.com"
+    ).strip().rstrip("/")
+
+    if not public_key or not secret_key:
+        print(
+            "[smoke] LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY are not set. "
+            "Fill them into apps/ai/.env.dev or apps/ai/.env and re-run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"[smoke] using Langfuse host -> {host}")
+
+    from langfuse import Langfuse
+
+    client = Langfuse(
+        public_key=public_key,
+        secret_key=secret_key,
+        base_url=host,
+    )
+
+    # auth_check() returns True on success, but on bad credentials / wrong host
+    # the SDK raises (e.g. UnauthorizedError) instead of returning False -- treat
+    # both as a failure and exit non-zero with a readable message.
+    try:
+        authed = client.auth_check()
+    except Exception as error:  # noqa: BLE001
+        print(
+            f"[smoke] auth_check() failed: {error}\n"
+            "        check LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_HOST and network.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not authed:
+        print(
+            "[smoke] auth_check() returned False: check your keys and host / network.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print("[smoke] auth_check() OK")
+
+    with client.start_as_current_span(name="quickvoice-langfuse-smoke") as span:
+        span.update(
+            input={"probe": "hello from quickvoice"},
+            output={"status": "ok"},
+            metadata={"source": "scripts/langfuse_smoke.py", "component": "connectivity-test"},
+        )
+
+    client.flush()
+
+    print(
+        "[smoke] sent one trace 'quickvoice-langfuse-smoke'. "
+        f"Look for it in your Langfuse project at {host} -> Tracing."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/ai/utils/telemetry.py
+++ b/apps/ai/utils/telemetry.py
@@ -1,0 +1,76 @@
+"""
+Langfuse tracing for the QuickVoice AI voice agent.
+
+QuickVoice's voice pipeline runs on LiveKit Agents, which already emits
+OpenTelemetry spans for the AgentSession, the LLM / STT / TTS calls, and every
+tool call. Langfuse registers itself as an OpenTelemetry span processor, so the
+whole integration is: build ONE TracerProvider, hand it to both LiveKit
+(`set_tracer_provider`) and Langfuse, and every voice turn shows up in the
+Langfuse dashboard with no change to the call logic itself.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from utils.logger import logger
+
+
+def _tracing_enabled() -> bool:
+    return os.getenv("LANGFUSE_TRACING_ENABLED", "true").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def setup_langfuse_tracing(metadata: Optional[dict] = None):
+    """
+    Point LiveKit Agents' OpenTelemetry tracer at Langfuse. Returns the
+    TracerProvider when active, else None. Never raises: observability must never
+    take down a live call. Pass metadata={"langfuse.session.id": ctx.room.name}
+    so all spans from one call group into a single Langfuse session.
+    """
+    if not _tracing_enabled():
+        logger.info("[langfuse] tracing disabled via LANGFUSE_TRACING_ENABLED")
+        return None
+
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY", "").strip()
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY", "").strip()
+    host = (
+        os.getenv("LANGFUSE_HOST")
+        or os.getenv("LANGFUSE_BASE_URL")
+        or "https://cloud.langfuse.com"
+    ).strip().rstrip("/")
+
+    if not public_key or not secret_key:
+        logger.warning("[langfuse] LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set; running untraced")
+        return None
+
+    try:
+        from langfuse import Langfuse
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from livekit.agents.telemetry import set_tracer_provider
+
+        trace_provider = TracerProvider()
+        set_tracer_provider(trace_provider, metadata=metadata or {})
+
+        # Handing the shared TracerProvider to Langfuse registers its
+        # LangfuseSpanProcessor on it, so every span LiveKit emits on this
+        # provider is exported to Langfuse. Exporting all spans is the default
+        # processor behaviour, so no per-span filter is needed here.
+        Langfuse(
+            public_key=public_key,
+            secret_key=secret_key,
+            base_url=host,
+            tracer_provider=trace_provider,
+        )
+
+        logger.info("[langfuse] tracing enabled -> {}", host)
+        return trace_provider
+    except Exception as error:  # noqa: BLE001 - observability must never crash a call
+        logger.warning("[langfuse] failed to initialize tracing: {}", error)
+        return None


### PR DESCRIPTION
## Summary

-

## Issue Or Context

- Related issue:
- First-time contributor?:
- Area changed: README, docs, web app, console, API, AI worker, telephony, billing, or local tooling

## Verification

- [x] I ran the narrowest check that proves this change.
- [ ] I ran `task doctor` when local tooling, env files, Docker services, or setup docs changed.
- [x] I ran `pnpm ci:local` for shared code, CI, dependency, build, or release workflow changes, or documented the narrower check below.
- [ ] Dependency changes are intentional, reflected in `pnpm-lock.yaml`, and any audit suppression changes include an expiry date.
- [x] UI screenshots or recordings are attached for product UI changes, or this PR has no product UI surface.
- [x] Environment changes are documented in the relevant `.env.*.example`, workflow variable notes, or README section.
- [x] I added broader checks if this touches shared code, auth, billing, database models, runtime agent behavior, or production UI.
- [ ] For docs-only changes, I reviewed links, commands, and provider-credential boundaries.

Command or review evidence:

```sh

```

## Launch And Positioning Guardrails

- [x] Public copy keeps the open-source Retell alternative story focused on control, self-hosting, privacy review, cost visibility, and extensibility.
- [x] Competitive comparisons explain tradeoffs without attacking competitors.
- [x] This PR does not invent screenshots, metrics, benchmarks, customers, compliance claims, provider partnerships, or production readiness claims.
- [x] Provider requirements are explicit when real calls, billing, OAuth, email, storage, or deployment need live credentials or product decisions.

## Screenshots Or Recordings

Add only real screenshots or recordings captured from the current product or a documented local/demo environment.

## Maintainer Review Notes

- Is this safe for a first-time contributor path, or does it need owner review because it touches credentials, auth, billing, migrations, runtime workers, or provider architecture?
- If this is a launch-day PR, provide a first response within 24 launch hours even when full review needs more time.
