### PR TITLE
Integrate Langfuse call-level evaluation in AI finalization flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,14 @@ DEEPGRAM_API_KEY=your-deepgram-key
 ELEVENLABS_API_KEY=your-elevenlabs-key
 ELEVENLABS_DEFAULT_VOICE_ID=your-voice-id
 SARVAM_API_KEY=your-sarvam-key
+# Optional: Langfuse call-level evaluation tracing
+LANGFUSE_ENABLED=true
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
 ```
+
+When Langfuse is enabled, QuickVoice publishes a per-call evaluation trace at shutdown with call-level quality metrics (`call_completed`, `agent_response_rate`, `turn_balance`) and any configured `data_evaluated` results as Langfuse scores.
 
 Run the AI API and worker, then create a session through the embedded broker:
 

--- a/apps/ai/.env.dev.example
+++ b/apps/ai/.env.dev.example
@@ -7,6 +7,10 @@ INTERNAL_API_KEY=dev-internal-key-change-me
 REDIS_URL=redis://localhost:6379
 LIVE_TRANSCRIPT_TTL_SECONDS=3600
 LIVE_TRANSCRIPT_QUEUE_SIZE=256
+LANGFUSE_ENABLED=false
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
 
 LIVEKIT_URL=wss://your-livekit-host
 LIVEKIT_API_KEY=dev-livekit-api-key

--- a/apps/ai/handlers/finalization_handler.py
+++ b/apps/ai/handlers/finalization_handler.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from handlers.calllog_handler import build_call_log_payload, post_call_log_with_retry
+from handlers.langfuse_evaluation_handler import LangfuseEvaluationHandler
 from utils.logger import logger, redact_sensitive
 
 
@@ -17,6 +18,7 @@ class CallFinalizer:
         recording_path: str | None,
         transcript_reader: Callable[[], list[dict[str, Any]]],
         post_call_log: Callable[[dict[str, Any]], Awaitable[Any]] | None = None,
+        langfuse_evaluation_handler: LangfuseEvaluationHandler | None = None,
     ):
         self._config = config
         self._call_context = call_context
@@ -24,6 +26,11 @@ class CallFinalizer:
         self._recording_path = recording_path
         self._transcript_reader = transcript_reader
         self._post_call_log = post_call_log or post_call_log_with_retry
+        self._langfuse_evaluation_handler = (
+            langfuse_evaluation_handler
+            if langfuse_evaluation_handler is not None
+            else LangfuseEvaluationHandler.from_env()
+        )
         self._lock = asyncio.Lock()
         self._completed = False
 
@@ -51,4 +58,13 @@ class CallFinalizer:
             if self._config.get("retention_days") is not None:
                 payload["metadata"]["retentionDays"] = self._config.get("retention_days")
             await self._post_call_log(payload)
+            if self._langfuse_evaluation_handler is not None:
+                self._langfuse_evaluation_handler.publish_call_evaluations(
+                    config=self._config,
+                    call_context=self._call_context,
+                    started_at=self._started_at,
+                    ended_at=ended_at,
+                    transcripts=transcript,
+                    payload=payload,
+                )
             logger.info("[CALL_LOG] finalized call {}", redact_sensitive({"callId": payload["callId"]}))

--- a/apps/ai/handlers/langfuse_evaluation_handler.py
+++ b/apps/ai/handlers/langfuse_evaluation_handler.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any
+
+from utils.logger import logger, redact_sensitive
+
+LANGFUSE_REQUIRED_ENV = (
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_BASE_URL",
+)
+
+
+class LangfuseEvaluationHandler:
+    def __init__(self, client: Any):
+        self._client = client
+
+    @classmethod
+    def from_env(cls) -> "LangfuseEvaluationHandler | None":
+        if not _env_bool("LANGFUSE_ENABLED", default=False):
+            return None
+
+        missing = [name for name in LANGFUSE_REQUIRED_ENV if not os.getenv(name)]
+        if missing:
+            raise RuntimeError(f"Missing required Langfuse environment variables: {', '.join(missing)}")
+
+        from langfuse import get_client
+
+        return cls(get_client())
+
+    def publish_call_evaluations(
+        self,
+        *,
+        config: dict[str, Any],
+        call_context: dict[str, Any],
+        started_at: datetime,
+        ended_at: datetime,
+        transcripts: list[dict[str, Any]],
+        payload: dict[str, Any],
+    ) -> None:
+        call_id = str(payload.get("callId") or call_context.get("call_id") or "").strip()
+        if not call_id:
+            raise ValueError("callId is required for Langfuse evaluation")
+
+        trace_id = self._client.create_trace_id(seed=f"quickvoice:{call_id}")
+        zero_pii_retention = bool(config.get("zero_pii_retention"))
+        user_messages, agent_messages = _split_transcripts(transcripts)
+        duration_seconds = max(0, int((ended_at - started_at).total_seconds()))
+
+        input_text = None if zero_pii_retention else "\n".join(user_messages) or None
+        output_text = None if zero_pii_retention else "\n".join(agent_messages) or None
+
+        metadata = {
+            "callId": call_id,
+            "agentId": payload.get("agentId"),
+            "organizationId": payload.get("organizationId"),
+            "direction": payload.get("direction"),
+            "provider": payload.get("provider"),
+            "durationSeconds": duration_seconds,
+            "userTurns": len(user_messages),
+            "agentTurns": len(agent_messages),
+            "zeroPiiRetention": zero_pii_retention,
+        }
+        if not zero_pii_retention:
+            metadata["summary"] = ((payload.get("metadata") or {}).get("summary") or "")[:500]
+
+        with self._client.start_as_current_observation(
+            trace_context={"trace_id": trace_id},
+            name="quickvoice-call-evaluation",
+            as_type="evaluator",
+            input=input_text,
+            output=output_text,
+            metadata=metadata,
+        ) as observation:
+            observation.score_trace(
+                name="call_completed",
+                value=1 if str(payload.get("status") or "").upper() == "COMPLETED" else 0,
+                data_type="BOOLEAN",
+            )
+
+            response_rate = _agent_response_rate(user_turns=len(user_messages), agent_turns=len(agent_messages))
+            if response_rate is not None:
+                observation.score_trace(
+                    name="agent_response_rate",
+                    value=response_rate,
+                    data_type="NUMERIC",
+                )
+
+            turn_balance = _turn_balance(user_turns=len(user_messages), agent_turns=len(agent_messages))
+            if turn_balance is not None:
+                observation.score_trace(
+                    name="turn_balance",
+                    value=turn_balance,
+                    data_type="NUMERIC",
+                )
+
+            for configured_score in _configured_scores(payload.get("evaluatedData")):
+                observation.score_trace(**configured_score)
+
+        self._client.flush()
+        logger.info(
+            "[LANGFUSE] published call evaluation {}",
+            redact_sensitive({"callId": call_id, "traceId": trace_id}),
+        )
+
+
+def _configured_scores(evaluated_data: Any) -> list[dict[str, Any]]:
+    if not isinstance(evaluated_data, list):
+        return []
+
+    scores: list[dict[str, Any]] = []
+    for item in evaluated_data:
+        if not isinstance(item, dict):
+            continue
+        identifier = str(item.get("identifier") or item.get("name") or "").strip()
+        if not identifier:
+            continue
+        value = item.get("value")
+        description = str(item.get("description") or "").strip()
+        parsed = _score_value(value)
+        if parsed is None:
+            continue
+
+        score_payload: dict[str, Any] = {
+            "name": f"configured_{identifier}",
+            "value": parsed["value"],
+            "data_type": parsed["data_type"],
+        }
+        if description:
+            score_payload["comment"] = description
+        scores.append(score_payload)
+    return scores
+
+
+def _score_value(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, bool):
+        return {"value": 1 if value else 0, "data_type": "BOOLEAN"}
+    if isinstance(value, (int, float)):
+        return {"value": float(value), "data_type": "NUMERIC"}
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "yes", "y", "pass", "passed"}:
+            return {"value": 1, "data_type": "BOOLEAN"}
+        if normalized in {"false", "no", "n", "fail", "failed"}:
+            return {"value": 0, "data_type": "BOOLEAN"}
+        if normalized:
+            return {"value": value.strip(), "data_type": "CATEGORICAL"}
+    return None
+
+
+def _split_transcripts(transcripts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    user_messages: list[str] = []
+    agent_messages: list[str] = []
+    for item in transcripts:
+        role = str(item.get("role") or "").strip().lower()
+        if role == "assistant":
+            role = "agent"
+        if role not in {"user", "agent"}:
+            continue
+
+        message = item.get("message", item.get("content", ""))
+        if isinstance(message, list):
+            message = " ".join(str(part) for part in message)
+        message = str(message or "").strip()
+        if not message:
+            continue
+        if role == "user":
+            user_messages.append(message)
+        else:
+            agent_messages.append(message)
+    return user_messages, agent_messages
+
+
+def _agent_response_rate(*, user_turns: int, agent_turns: int) -> float | None:
+    if user_turns <= 0:
+        return None
+    return round(min(agent_turns / user_turns, 1.0), 4)
+
+
+def _turn_balance(*, user_turns: int, agent_turns: int) -> float | None:
+    total_turns = user_turns + agent_turns
+    if total_turns <= 0:
+        return None
+    return round(min(user_turns, agent_turns) / max(user_turns, agent_turns), 4) if max(user_turns, agent_turns) else None
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}

--- a/apps/ai/requirements.txt
+++ b/apps/ai/requirements.txt
@@ -20,3 +20,4 @@ xlrd>=2.0,<3
 httpx>=0.27,<1
 beautifulsoup4>=4.12,<5
 redis>=5,<7
+langfuse>=4.0,<5

--- a/apps/ai/tests/test_finalization_handler.py
+++ b/apps/ai/tests/test_finalization_handler.py
@@ -90,6 +90,41 @@ class FinalizationHandlerTests(unittest.TestCase):
         self.assertTrue(posts[0]["metadata"]["zeroPiiRetention"])
         self.assertEqual(posts[0]["metadata"]["retentionDays"], 3)
 
+    def test_call_finalizer_publishes_langfuse_evaluations_when_handler_is_injected(self):
+        posts = []
+        eval_calls = []
+
+        def transcript_reader():
+            return [{"role": "user", "content": "Hello", "time": datetime(2026, 1, 1, tzinfo=timezone.utc)}]
+
+        async def post_call_log(payload):
+            posts.append(payload)
+
+        class FakeLangfuseHandler:
+            def publish_call_evaluations(self, **kwargs):
+                eval_calls.append(kwargs)
+
+        finalizer = CallFinalizer(
+            config={"agent_id": "agent_123", "organization_id": "org_123"},
+            call_context={
+                "call_id": "call_123",
+                "from_number": "+15550001111",
+                "to_number": "+15551230000",
+            },
+            started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            recording_path=None,
+            transcript_reader=transcript_reader,
+            post_call_log=post_call_log,
+            langfuse_evaluation_handler=FakeLangfuseHandler(),
+        )
+
+        asyncio.run(finalizer.finalize())
+
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(len(eval_calls), 1)
+        self.assertEqual(eval_calls[0]["payload"]["callId"], "call_123")
+        self.assertEqual(eval_calls[0]["transcripts"][0]["content"], "Hello")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/apps/ai/tests/test_langfuse_evaluation_handler.py
+++ b/apps/ai/tests/test_langfuse_evaluation_handler.py
@@ -1,0 +1,132 @@
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from handlers.langfuse_evaluation_handler import LangfuseEvaluationHandler
+
+
+class _FakeObservation:
+    def __init__(self):
+        self.trace_scores = []
+
+    def score_trace(self, **kwargs):
+        self.trace_scores.append(kwargs)
+
+
+class _FakeContextManager:
+    def __init__(self, observation):
+        self._observation = observation
+
+    def __enter__(self):
+        return self._observation
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeLangfuseClient:
+    def __init__(self):
+        self.observation = _FakeObservation()
+        self.started_with = None
+        self.flush_called = False
+
+    def create_trace_id(self, *, seed: str) -> str:
+        return f"trace-{seed}"
+
+    def start_as_current_observation(self, **kwargs):
+        self.started_with = kwargs
+        return _FakeContextManager(self.observation)
+
+    def flush(self):
+        self.flush_called = True
+
+
+class LangfuseEvaluationHandlerTests(unittest.TestCase):
+    def test_publish_call_evaluations_sends_core_and_configured_scores(self):
+        client = _FakeLangfuseClient()
+        handler = LangfuseEvaluationHandler(client)
+
+        handler.publish_call_evaluations(
+            config={"zero_pii_retention": False},
+            call_context={"call_id": "call_123"},
+            started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc),
+            transcripts=[
+                {"role": "user", "content": "I need help with billing"},
+                {"role": "agent", "content": "Sure, I can help with billing"},
+            ],
+            payload={
+                "callId": "call_123",
+                "agentId": "agent_123",
+                "organizationId": "org_123",
+                "status": "COMPLETED",
+                "direction": "inbound",
+                "provider": "TWILIO",
+                "metadata": {"summary": "Billing support call"},
+                "evaluatedData": [
+                    {"identifier": "qualified_lead", "description": "lead status", "value": True},
+                    {"identifier": "intent", "description": "intent label", "value": "billing"},
+                ],
+            },
+        )
+
+        self.assertTrue(client.flush_called)
+        self.assertEqual(client.started_with["as_type"], "evaluator")
+        self.assertEqual(client.started_with["trace_context"]["trace_id"], "trace-quickvoice:call_123")
+        self.assertEqual(client.started_with["input"], "I need help with billing")
+        self.assertEqual(client.started_with["output"], "Sure, I can help with billing")
+
+        scores_by_name = {item["name"]: item for item in client.observation.trace_scores}
+        self.assertEqual(scores_by_name["call_completed"]["data_type"], "BOOLEAN")
+        self.assertEqual(scores_by_name["call_completed"]["value"], 1)
+        self.assertEqual(scores_by_name["configured_qualified_lead"]["data_type"], "BOOLEAN")
+        self.assertEqual(scores_by_name["configured_qualified_lead"]["value"], 1)
+        self.assertEqual(scores_by_name["configured_intent"]["data_type"], "CATEGORICAL")
+        self.assertEqual(scores_by_name["configured_intent"]["value"], "billing")
+
+    def test_publish_call_evaluations_omits_transcript_when_zero_pii_retention_enabled(self):
+        client = _FakeLangfuseClient()
+        handler = LangfuseEvaluationHandler(client)
+
+        handler.publish_call_evaluations(
+            config={"zero_pii_retention": True},
+            call_context={"call_id": "call_123"},
+            started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc),
+            transcripts=[
+                {"role": "user", "content": "Sensitive value"},
+                {"role": "agent", "content": "Sensitive response"},
+            ],
+            payload={
+                "callId": "call_123",
+                "agentId": "agent_123",
+                "organizationId": "org_123",
+                "status": "COMPLETED",
+                "direction": "inbound",
+                "provider": "TWILIO",
+                "metadata": {"summary": "Sensitive summary"},
+                "evaluatedData": [],
+            },
+        )
+
+        self.assertIsNone(client.started_with["input"])
+        self.assertIsNone(client.started_with["output"])
+        self.assertNotIn("summary", client.started_with["metadata"])
+
+    def test_from_env_returns_none_when_disabled(self):
+        with patch.dict(os.environ, {"LANGFUSE_ENABLED": "false"}, clear=False):
+            self.assertIsNone(LangfuseEvaluationHandler.from_env())
+
+    def test_from_env_raises_when_enabled_without_required_variables(self):
+        with patch.dict(os.environ, {"LANGFUSE_ENABLED": "true"}, clear=True):
+            with self.assertRaises(RuntimeError):
+                LangfuseEvaluationHandler.from_env()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

-

## Issue Or Context

- Related issue:
- First-time contributor?:
- Area changed: README, docs, web app, console, API, AI worker, telephony, billing, or local tooling

## Verification

- [ ] I ran the narrowest check that proves this change.
- [ ] I ran `task doctor` when local tooling, env files, Docker services, or setup docs changed.
- [ ] I ran `pnpm ci:local` for shared code, CI, dependency, build, or release workflow changes, or documented the narrower check below.
- [ ] Dependency changes are intentional, reflected in `pnpm-lock.yaml`, and any audit suppression changes include an expiry date.
- [ ] UI screenshots or recordings are attached for product UI changes, or this PR has no product UI surface.
- [ ] Environment changes are documented in the relevant `.env.*.example`, workflow variable notes, or README section.
- [ ] I added broader checks if this touches shared code, auth, billing, database models, runtime agent behavior, or production UI.
- [ ] For docs-only changes, I reviewed links, commands, and provider-credential boundaries.

Command or review evidence:

```sh

```

## Launch And Positioning Guardrails

- [ ] Public copy keeps the open-source Retell alternative story focused on control, self-hosting, privacy review, cost visibility, and extensibility.
- [ ] Competitive comparisons explain tradeoffs without attacking competitors.
- [ ] This PR does not invent screenshots, metrics, benchmarks, customers, compliance claims, provider partnerships, or production readiness claims.
- [ ] Provider requirements are explicit when real calls, billing, OAuth, email, storage, or deployment need live credentials or product decisions.

## Screenshots Or Recordings

Add only real screenshots or recordings captured from the current product or a documented local/demo environment.

## Maintainer Review Notes

- Is this safe for a first-time contributor path, or does it need owner review because it touches credentials, auth, billing, migrations, runtime workers, or provider architecture?
- If this is a launch-day PR, provide a first response within 24 launch hours even when full review needs more time.
