### PR TITLE
Document the comprehensive voice platform roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,21 @@ QuickVoice is an actively developed, pre-stable open-source project. This roadma
 
 Priorities may change in response to security findings, setup failures, maintainer capacity, and real user feedback. Propose or discuss roadmap changes through the feature issue form rather than opening a broad implementation pull request.
 
+## Comprehensive Product Roadmap
+
+The implementation backlog for expanding QuickVoice into a comprehensive AI voice-agent platform is tracked in [roadmap issue #76](https://github.com/allgpt-co/QuickVoice/issues/76). It is organized into eight design epics:
+
+- [Visual orchestration, versions, and deployment](https://github.com/allgpt-co/QuickVoice/issues/77)
+- [Templates, onboarding, and solution blueprints](https://github.com/allgpt-co/QuickVoice/issues/78)
+- [Customer data and campaigns](https://github.com/allgpt-co/QuickVoice/issues/79)
+- [Analytics, conversation intelligence, evaluations, and experiments](https://github.com/allgpt-co/QuickVoice/issues/80)
+- [API, MCP, integrations, and data portability](https://github.com/allgpt-co/QuickVoice/issues/81)
+- [Telephony, channels, and runtime reliability](https://github.com/allgpt-co/QuickVoice/issues/82)
+- [Enterprise governance, security, privacy, and compliance controls](https://github.com/allgpt-co/QuickVoice/issues/83)
+- [Platform UX, collaboration, commercial operations, and ecosystem](https://github.com/allgpt-co/QuickVoice/issues/84)
+
+These issues describe proposed outcomes and acceptance criteria. They do not imply that the capabilities have shipped or that QuickVoice holds a compliance certification.
+
 ## Release Baseline
 
 - Make a clean-clone local setup repeatable on Linux, macOS with modern Bash, and WSL2.
@@ -44,8 +59,8 @@ The roadmap does not mean QuickVoice currently provides:
 - A zero-configuration hosted phone-agent service.
 - Working live calls without provider accounts and credentials.
 - A compliance certification or automatic compliance for a deployment.
-- Guaranteed compatibility before a stable release.
-- Guaranteed response, fix, or delivery times.
+- Compatibility is not guaranteed before a stable release.
+- Response, fix, or delivery times are not guaranteed.
 - Support for native Windows PowerShell orchestration.
 
 See [SUPPORT.md](./SUPPORT.md) for help boundaries, [GOVERNANCE.md](./GOVERNANCE.md) for decisions, and [CHANGELOG.md](./CHANGELOG.md) for changes that have actually landed.


### PR DESCRIPTION
## What changed

- Link the repository roadmap to the comprehensive product roadmap in #76.
- List the eight design epics covering orchestration, templates, campaigns, analytics/evals, developer integrations, telephony, enterprise controls, and platform operations.
- Clarify that proposed issues are not shipped capabilities or compliance claims.
- Rewrite two existing non-claim bullets so the public-claims audit parses their intent correctly.

## Why

The newly created 48-issue backlog should be discoverable from the repository's canonical roadmap without presenting proposed capabilities as current product behavior.

## User and developer impact

Maintainers, contributors, and evaluators can navigate from `ROADMAP.md` to the portfolio issue and implementation-ready epics. No runtime, API, database, or deployment behavior changes.

## Validation

- `node --jitless .../prettier.cjs --check ROADMAP.md`
- `node --jitless scripts/audit-public-claims.mjs --target ROADMAP.md`
- `NODE_OPTIONS=--jitless node --jitless --test tests/public-claims-audit.test.mjs`
- `git diff --check`
- Verified roadmap issue #76 and epics #77–#84 are open and resolve successfully.