### PR TITLE
Add Langfuse observability integration

### DIFF
--- a/apps/ai/main.py
+++ b/apps/ai/main.py
@@ -41,6 +41,7 @@ from handlers.voice_provider_adapters import ProviderAdapterError, build_voice_p
 from handlers.voice_worker_metadata import is_voice_session_metadata, parse_voice_session_metadata
 from utils.logger import logger
 from utils.logger import redact_sensitive
+from utils.langfuse_setup import setup_langfuse
 import asyncio
 import json
 from datetime import datetime, timezone
@@ -438,6 +439,7 @@ async def entrypoint(ctx: JobContext):
     logger.info("Entrypoint called with room: {}", redact_sensitive(ctx.room.name))
 
     await ctx.connect()
+    setup_langfuse()
     raw_metadata = ctx.job.metadata or ""
     if is_voice_session_metadata(raw_metadata):
         voice_metadata = parse_voice_session_metadata(raw_metadata)

--- a/apps/ai/requirements.txt
+++ b/apps/ai/requirements.txt
@@ -20,3 +20,5 @@ xlrd>=2.0,<3
 httpx>=0.27,<1
 beautifulsoup4>=4.12,<5
 redis>=5,<7
+langfuse
+opentelemetry-sdk

--- a/apps/ai/utils/langfuse_setup.py
+++ b/apps/ai/utils/langfuse_setup.py
@@ -1,0 +1,27 @@
+import os
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from livekit.agents.telemetry import set_tracer_provider
+from langfuse import Langfuse
+
+
+def setup_langfuse() -> TracerProvider:
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+    base_url = os.getenv("LANGFUSE_BASE_URL") or os.getenv("LANGFUSE_HOST")
+
+    if not public_key or not secret_key or not base_url:
+        raise ValueError(
+            "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_HOST must be set"
+        )
+
+    # Langfuse v4 sets up its own global OpenTelemetry TracerProvider internally
+    Langfuse(public_key=public_key, secret_key=secret_key, base_url=base_url)
+
+    # Point LiveKit's agent spans at that same global provider
+    tracer_provider = trace.get_tracer_provider()
+    set_tracer_provider(tracer_provider)
+
+    return tracer_provider


### PR DESCRIPTION
## Summary

-Integrates Langfuse (via LiveKit Agents' built-in OpenTelemetry support) 
   for LLM call tracing, latency, and cost observability during voice sessions.

## Issue Or Context

- Related issue:
- First-time contributor?:
- Area changed: README, docs, web app, console, API, AI worker, telephony, billing, or local tooling

## Verification

- [ ] I ran the narrowest check that proves this change.
- [ ] I ran `task doctor` when local tooling, env files, Docker services, or setup docs changed.
- [ ] I ran `pnpm ci:local` for shared code, CI, dependency, build, or release workflow changes, or documented the narrower check below.
- [ ] Dependency changes are intentional, reflected in `pnpm-lock.yaml`, and any audit suppression changes include an expiry date.
- [ ] UI screenshots or recordings are attached for product UI changes, or this PR has no product UI surface.
- [ ] Environment changes are documented in the relevant `.env.*.example`, workflow variable notes, or README section.
- [ ] I added broader checks if this touches shared code, auth, billing, database models, runtime agent behavior, or production UI.
- [ ] For docs-only changes, I reviewed links, commands, and provider-credential boundaries.

Command or review evidence:

```sh

```

## Launch And Positioning Guardrails

- [ ] Public copy keeps the open-source Retell alternative story focused on control, self-hosting, privacy review, cost visibility, and extensibility.
- [ ] Competitive comparisons explain tradeoffs without attacking competitors.
- [ ] This PR does not invent screenshots, metrics, benchmarks, customers, compliance claims, provider partnerships, or production readiness claims.
- [ ] Provider requirements are explicit when real calls, billing, OAuth, email, storage, or deployment need live credentials or product decisions.

## Screenshots Or Recordings

Add only real screenshots or recordings captured from the current product or a documented local/demo environment.

## Maintainer Review Notes

- Is this safe for a first-time contributor path, or does it need owner review because it touches credentials, auth, billing, migrations, runtime workers, or provider architecture?
- If this is a launch-day PR, provide a first response within 24 launch hours even when full review needs more time.
