### PR TITLE
Integrate Langfuse evaluation layer

### DIFF
--- a/apps/ai/main.py
+++ b/apps/ai/main.py
@@ -1,4 +1,5 @@
 from dotenv import load_dotenv
+from utils.langfuse_setup import setup_langfuse
 
 from livekit import agents, rtc
 from livekit.agents import (
@@ -433,9 +434,19 @@ class Assistant(Agent):
         )
         return json.dumps(result.get("data", result), ensure_ascii=False)
 
-
 async def entrypoint(ctx: JobContext):
     logger.info("Entrypoint called with room: {}", redact_sensitive(ctx.room.name))
+
+    trace_provider = setup_langfuse(
+        metadata={
+            "langfuse.session.id": ctx.room.name,
+        }
+    )
+
+    async def flush_trace():
+        trace_provider.force_flush()
+
+    ctx.add_shutdown_callback(flush_trace)
 
     await ctx.connect()
     raw_metadata = ctx.job.metadata or ""

--- a/apps/ai/utils/langfuse_setup.py
+++ b/apps/ai/utils/langfuse_setup.py
@@ -1,0 +1,24 @@
+import os
+
+from langfuse import Langfuse
+from livekit.agents.telemetry import set_tracer_provider
+from opentelemetry.sdk.trace import TracerProvider
+
+
+def setup_langfuse(metadata=None):
+    trace_provider = TracerProvider()
+
+    set_tracer_provider(
+        trace_provider,
+        metadata=metadata,
+    )
+
+    Langfuse(
+        public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
+        secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
+        base_url=os.getenv("LANGFUSE_BASE_URL"),
+        tracer_provider=trace_provider,
+        should_export_span=lambda span: True,
+    )
+
+    return trace_provider


### PR DESCRIPTION
## Summary

- Integrated Langfuse observability into the AI worker.
- Added a Langfuse setup utility for tracer initialization.
- Initialized Langfuse during worker startup.
- Added a shutdown callback to flush traces before worker exit.

## Issue Or Context

- Related issue: N/A (Internship assignment)
- First-time contributor?: Yes
- Area changed: AI worker

## Verification

- [x] I ran the narrowest check that proves this change.
- [ ] I ran `task doctor` when local tooling, env files, Docker services, or setup docs changed.
- [ ] I ran `pnpm ci:local` for shared code, CI, dependency, build, or release workflow changes, or documented the narrower check below.
- [x] Dependency changes are intentional, reflected in the project requirements.
- [ ] UI screenshots or recordings are attached for product UI changes, or this PR has no product UI surface.
- [ ] Environment changes are documented in the relevant `.env.*.example`, workflow variable notes, or README section.
- [x] I added broader checks if this touches shared code, auth, billing, database models, runtime agent behavior, or production UI.
- [x] For docs-only changes, I reviewed links, commands, and provider-credential boundaries.

Command or review evidence:

```sh
python -m py_compile apps/ai/main.py
python apps/ai/main.py start

## Screenshots Or Recordings

Demo Video:

https://drive.google.com/file/d/1sh0NWUp2zjXY9TQTc8e_oV3gMyy0S0rK/view?usp=sharing


