### PR TITLE
Integrate Langfuse tracing into AI worker

### DIFF
--- a/apps/ai/.env.dev.example
+++ b/apps/ai/.env.dev.example
@@ -49,3 +49,6 @@ S3_BUCKET_NAME=quickvoice-dev
 ACCESS_KEY=dev-s3-access-key
 SECRET_ACCESS_KEY=dev-s3-secret-access-key
 REGION=us-east-1
+LANGFUSE_SECRET_KEY=sk-lf-dee6753b-246a-48c7-a68a-e1cc26df75be
+LANGFUSE_PUBLIC_KEY=pk-lf-31248129-7d3c-4c8b-a4e5-46ed8e4e6511
+LANGFUSE_BASE_URL=https://cloud.langfuse.com

--- a/apps/ai/main.py
+++ b/apps/ai/main.py
@@ -41,6 +41,7 @@ from handlers.voice_provider_adapters import ProviderAdapterError, build_voice_p
 from handlers.voice_worker_metadata import is_voice_session_metadata, parse_voice_session_metadata
 from utils.logger import logger
 from utils.logger import redact_sensitive
+from utils.langfuse_client import setup_langfuse
 import asyncio
 import json
 from datetime import datetime, timezone
@@ -433,9 +434,19 @@ class Assistant(Agent):
         )
         return json.dumps(result.get("data", result), ensure_ascii=False)
 
-
 async def entrypoint(ctx: JobContext):
     logger.info("Entrypoint called with room: {}", redact_sensitive(ctx.room.name))
+
+    trace_provider = setup_langfuse(
+        metadata={
+            "langfuse.session.id": ctx.room.name,
+        }
+    )
+
+    async def flush_trace():
+        trace_provider.force_flush()
+
+    ctx.add_shutdown_callback(flush_trace)
 
     await ctx.connect()
     raw_metadata = ctx.job.metadata or ""

--- a/apps/ai/requirements.txt
+++ b/apps/ai/requirements.txt
@@ -20,3 +20,4 @@ xlrd>=2.0,<3
 httpx>=0.27,<1
 beautifulsoup4>=4.12,<5
 redis>=5,<7
+langfuse>=3.0.0

--- a/apps/ai/utils/langfuse_client.py
+++ b/apps/ai/utils/langfuse_client.py
@@ -1,0 +1,36 @@
+import os
+
+from langfuse import Langfuse
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.util.types import AttributeValue
+
+from livekit.agents.telemetry import set_tracer_provider
+
+
+def setup_langfuse(
+    metadata: dict[str, AttributeValue] | None = None,
+) -> TracerProvider:
+
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+    base_url = os.getenv("LANGFUSE_BASE_URL")
+
+    if not public_key or not secret_key or not base_url:
+        raise ValueError(
+            "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL must be set"
+        )
+
+    trace_provider = TracerProvider()
+
+    set_tracer_provider(trace_provider, metadata=metadata)
+
+    Langfuse(
+        public_key=public_key,
+        secret_key=secret_key,
+        base_url=base_url,
+        tracer_provider=trace_provider,
+        should_export_span=lambda span: True,
+    )
+    print("✅ Langfuse initialized successfully")
+
+    return trace_provider


### PR DESCRIPTION
## Summary

- Added Langfuse client setup for AI worker tracing.
- Initialized Langfuse tracing during AI worker startup.
- Added session metadata for traces.
- Flushes traces during worker shutdown.

## Testing

- AI worker starts successfully.
- AI worker registers with LiveKit.
- Langfuse environment variables configured.