### PR TITLE
Add Langfuse observability for LiveKit agents

### DIFF
--- a/apps/ai/main.py
+++ b/apps/ai/main.py
@@ -41,6 +41,7 @@ from handlers.voice_provider_adapters import ProviderAdapterError, build_voice_p
 from handlers.voice_worker_metadata import is_voice_session_metadata, parse_voice_session_metadata
 from utils.logger import logger
 from utils.logger import redact_sensitive
+from utils.langfuse import setup_langfuse
 import asyncio
 import json
 from datetime import datetime, timezone
@@ -437,6 +438,16 @@ class Assistant(Agent):
 async def entrypoint(ctx: JobContext):
     logger.info("Entrypoint called with room: {}", redact_sensitive(ctx.room.name))
 
+    tracer_provider = setup_langfuse()
+
+    if tracer_provider:
+        logger.info("[LANGFUSE] Job tracing enabled")
+
+        async def flush_langfuse_trace():
+            tracer_provider.force_flush()
+
+        ctx.add_shutdown_callback(flush_langfuse_trace)
+
     await ctx.connect()
     raw_metadata = ctx.job.metadata or ""
     if is_voice_session_metadata(raw_metadata):
@@ -641,6 +652,13 @@ if __name__ == "__main__":
             reload=os.getenv("AI_API_RELOAD", "false").lower() == "true",
         )
         raise SystemExit(0)
+
+    tracer_provider = setup_langfuse()
+
+    if tracer_provider:
+        logger.info("[LANGFUSE] Observability enabled")
+    else:
+        logger.info("[LANGFUSE] Observability disabled - credentials not configured")
 
     agents.cli.run_app(
         agents.WorkerOptions(

--- a/apps/ai/requirements.txt
+++ b/apps/ai/requirements.txt
@@ -20,3 +20,6 @@ xlrd>=2.0,<3
 httpx>=0.27,<1
 beautifulsoup4>=4.12,<5
 redis>=5,<7
+# LLM observability
+langfuse>=4,<5
+opentelemetry-sdk>=1.30,<2

--- a/apps/ai/utils/langfuse.py
+++ b/apps/ai/utils/langfuse.py
@@ -1,0 +1,33 @@
+import os
+
+from langfuse import Langfuse
+from livekit.agents.telemetry import set_tracer_provider
+from opentelemetry.sdk.trace import TracerProvider
+
+
+def setup_langfuse():
+    """Configure Langfuse observability for LiveKit Agents."""
+
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+    base_url = (
+        os.getenv("LANGFUSE_BASE_URL")
+        or os.getenv("LANGFUSE_HOST")
+    )
+
+    if not public_key or not secret_key or not base_url:
+        return None
+
+    tracer_provider = TracerProvider()
+
+    set_tracer_provider(tracer_provider)
+
+    Langfuse(
+        public_key=public_key,
+        secret_key=secret_key,
+        base_url=base_url,
+        tracer_provider=tracer_provider,
+        should_export_span=lambda span: True,
+    )
+
+    return tracer_provider


### PR DESCRIPTION
## Summary
- Add Langfuse observability integration for LiveKit agents
- Configure OpenTelemetry tracer provider
- Initialize tracing inside LiveKit job processes
- Flush traces during job shutdown
- Add Langfuse and OpenTelemetry SDK dependencies

## Testing
- 136 tests passed
- 5 subtests passed
- Verified LiveKit worker registration
- Verified voice session dispatch
- Verified traces and observations in Langfuse