### PR TITLE
Fix knowledge base status column overflow

### DIFF
--- a/apps/console/src/components/kb/KbTable.tsx
+++ b/apps/console/src/components/kb/KbTable.tsx
@@ -359,7 +359,7 @@ export function KbTable({ sources, agents, isLoading }: Props) {
                     ) : null}
                   </TableCell>
 
-                  <TableCell className="align-top">
+                  <TableCell className="w-[360px] max-w-[360px] whitespace-normal align-top">
                     <KnowledgeSourceStatus source={s} />
                     {progress ? (
                       <p className="mt-1 max-w-28 truncate capitalize text-xs text-muted-foreground">

--- a/apps/console/src/components/kb/kb-utils.tsx
+++ b/apps/console/src/components/kb/kb-utils.tsx
@@ -1,9 +1,4 @@
-import {
-  AlertCircle,
-  FileSpreadsheet,
-  FileText,
-  Globe,
-} from "lucide-react";
+import { AlertCircle, FileSpreadsheet, FileText, Globe } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type {
   KbSourceType,
@@ -12,16 +7,40 @@ import type {
 } from "@/src/lib/api/types";
 import { getKbErrorCopy } from "@/src/components/kb/kb-error-copy";
 
-export interface SourceMeta { Icon: LucideIcon; iconCls: string }
+export interface SourceMeta {
+  Icon: LucideIcon;
+  iconCls: string;
+}
 
 export const SOURCE_META: Record<KbSourceType, SourceMeta> = {
-  PDF:  { Icon: FileText,        iconCls: "border-red-500/20 bg-red-500/10 text-red-400" },
-  DOCX: { Icon: FileText,        iconCls: "border-blue-500/20 bg-blue-500/10 text-blue-400" },
-  TXT:  { Icon: FileText,        iconCls: "border-slate-500/20 bg-slate-500/10 text-slate-400" },
-  CSV:  { Icon: FileSpreadsheet, iconCls: "border-emerald-500/20 bg-emerald-500/10 text-emerald-400" },
-  XLSX: { Icon: FileSpreadsheet, iconCls: "border-emerald-500/20 bg-emerald-500/10 text-emerald-400" },
-  XLS:  { Icon: FileSpreadsheet, iconCls: "border-emerald-500/20 bg-emerald-500/10 text-emerald-400" },
-  URL:  { Icon: Globe,           iconCls: "border-violet-500/20 bg-violet-500/10 text-violet-400" },
+  PDF: {
+    Icon: FileText,
+    iconCls: "border-red-500/20 bg-red-500/10 text-red-400",
+  },
+  DOCX: {
+    Icon: FileText,
+    iconCls: "border-blue-500/20 bg-blue-500/10 text-blue-400",
+  },
+  TXT: {
+    Icon: FileText,
+    iconCls: "border-slate-500/20 bg-slate-500/10 text-slate-400",
+  },
+  CSV: {
+    Icon: FileSpreadsheet,
+    iconCls: "border-emerald-500/20 bg-emerald-500/10 text-emerald-400",
+  },
+  XLSX: {
+    Icon: FileSpreadsheet,
+    iconCls: "border-emerald-500/20 bg-emerald-500/10 text-emerald-400",
+  },
+  XLS: {
+    Icon: FileSpreadsheet,
+    iconCls: "border-emerald-500/20 bg-emerald-500/10 text-emerald-400",
+  },
+  URL: {
+    Icon: Globe,
+    iconCls: "border-violet-500/20 bg-violet-500/10 text-violet-400",
+  },
 };
 
 export const FALLBACK_META: SourceMeta = {
@@ -68,21 +87,25 @@ export function KnowledgeSourceStatus({
 
   return (
     <div
-      className={compact ? "max-w-sm space-y-1.5" : "max-w-md space-y-2"}
+      className={
+        compact
+          ? "min-w-0 max-w-sm space-y-1.5"
+          : "min-w-0 max-w-full space-y-2"
+      }
       role="status"
       aria-label={`Document processing failed: ${copy.reason}`}
     >
       <StatusChip status={source.status} />
       <div className="space-y-1 border-l-2 border-red-500/40 pl-2.5">
-        <p className="text-xs font-medium leading-5 text-foreground">
+        <p className="break-words text-xs font-medium leading-5 text-foreground">
           {copy.reason}
         </p>
-        <p className="text-xs leading-5 text-muted-foreground">
+        <p className="break-words text-xs leading-5 text-muted-foreground">
           <span className="font-medium text-foreground/80">How to fix:</span>{" "}
           {copy.guidance}
         </p>
         {source.errorCode ? (
-          <p className="font-mono text-[10px] leading-4 text-muted-foreground/80">
+          <p className="break-all font-mono text-[10px] leading-4 text-muted-foreground/80">
             Error code: {source.errorCode}
           </p>
         ) : null}

--- a/apps/console/tests/audit-fixes.test.mjs
+++ b/apps/console/tests/audit-fixes.test.mjs
@@ -157,6 +157,20 @@ test("knowledge-base failures expose progress, reasons, and retry controls", () 
   assert.match(table, /Retry/);
 });
 
+test("knowledge-base status details stay inside the desktop table column", () => {
+  const table = read("src/components/kb/KbTable.tsx");
+  const utils = read("src/components/kb/kb-utils.tsx");
+
+  assert.match(
+    table,
+    /w-\[360px\] max-w-\[360px\] whitespace-normal align-top/,
+  );
+  assert.match(utils, /min-w-0 max-w-full space-y-2/);
+  assert.match(utils, /break-words text-xs font-medium/);
+  assert.match(utils, /break-words text-xs leading-5/);
+  assert.match(utils, /break-all font-mono/);
+});
+
 test("auth registration and password reset flows have complete UX handling", () => {
   const register = read("src/components/forms/auth/register-form.tsx");
 


### PR DESCRIPTION
## Summary
- Constrain the desktop knowledge-base status table cell so long failure messages wrap inside the status column.
- Allow status reason/guidance text to break words and long error codes to break safely.
- Add a source-contract regression test for the status overflow behavior.

## Validation
- `git diff --check`
- `pnpm exec prettier --check apps/console/src/components/kb/KbTable.tsx apps/console/src/components/kb/kb-utils.tsx apps/console/tests/audit-fixes.test.mjs`
- `pnpm --filter console test`
- `pnpm --filter console lint`
- `pnpm --filter console check-types`