### PR TITLE
test(docs): add markdown link checker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ pnpm lint
 pnpm check-types
 pnpm test
 pnpm build
+pnpm docs:links
 pnpm ci:local
 pnpm audit:deps -- --audit-level low
 ```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:dev-orchestration": "node --test tests/dev-orchestration.test.mjs",
     "check:tasks": "node scripts/verify-turbo-tasks.mjs",
     "check:configs": "pnpm --filter @repo/eslint-config lint && pnpm --filter @repo/typescript-config lint",
+    "docs:links": "node scripts/check-markdown-links.mjs",
     "ci:python": "scripts/ci-python.sh",
     "ci:docker": "scripts/ci-docker-build.sh",
     "ci:local": "pnpm check:tasks && pnpm check:configs && pnpm lint && pnpm check-types && pnpm build && pnpm test && pnpm ci:python && pnpm ci:docker",

--- a/scripts/check-markdown-links.mjs
+++ b/scripts/check-markdown-links.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const EXCLUDED_DIRS = new Set([
+  ".git",
+  ".claude",
+  ".next",
+  ".turbo",
+  "coverage",
+  "dist",
+  "build",
+  "node_modules",
+  "out",
+]);
+
+const EXCLUDED_FILES = new Set(["audit.md", "ui_ux_audit.md"]);
+
+const IGNORED_SCHEMES = /^(?:https?:|mailto:|tel:|data:|javascript:|#?$)/i;
+
+function parseArgs(argv) {
+  const args = { root: process.cwd() };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--root") {
+      args.root = argv[i + 1];
+      i += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argv[i]}`);
+    }
+  }
+  return args;
+}
+
+function isInsideRoot(root, target) {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !rel.startsWith(sep));
+}
+
+async function walkMarkdown(root, dir = root) {
+  const files = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!EXCLUDED_DIRS.has(entry.name)) {
+        files.push(...(await walkMarkdown(root, join(dir, entry.name))));
+      }
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      const path = relative(root, join(dir, entry.name)).split(sep).join("/");
+      if (!EXCLUDED_FILES.has(path)) files.push(path);
+    }
+  }
+  return files;
+}
+
+async function listMarkdownFiles(root) {
+  const git = spawnSync("git", ["-C", root, "ls-files", "*.md"], {
+    encoding: "utf8",
+  });
+  if (git.status === 0) {
+    return git.stdout
+      .split("\n")
+      .filter(Boolean)
+      .filter(
+        (path) => !path.split("/").some((part) => EXCLUDED_DIRS.has(part)),
+      )
+      .filter((path) => !EXCLUDED_FILES.has(path))
+      .sort();
+  }
+  return (await walkMarkdown(root)).sort();
+}
+
+function stripMarkdownFormatting(text) {
+  return text
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/<[^>]+>/g, "")
+    .replace(/[*_~]/g, "");
+}
+
+function slugForHeading(text) {
+  return stripMarkdownFormatting(text)
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^\p{L}\p{N}-]/gu, "");
+}
+
+function headingSlugs(markdown) {
+  const slugs = new Set();
+  const seen = new Map();
+  for (const line of markdown.split(/\r?\n/)) {
+    const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
+    if (!match) continue;
+    const explicitId = /\s\{#([^}]+)\}\s*$/.exec(match[2]);
+    if (explicitId) slugs.add(explicitId[1].toLowerCase());
+    const headingText = explicitId
+      ? match[2].slice(0, explicitId.index)
+      : match[2];
+    const base = slugForHeading(headingText);
+    if (!base) continue;
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    slugs.add(count === 0 ? base : `${base}-${count}`);
+  }
+  return slugs;
+}
+
+function lineNumberAt(text, index) {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (text.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
+
+function markdownLinks(markdown) {
+  const links = [];
+  const pattern =
+    /!?\[[^\]\n]*(?:\][^\[\]\n]*\[[^\]\n]*)*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  for (const match of markdown.matchAll(pattern)) {
+    links.push({
+      href: match[1],
+      line: lineNumberAt(markdown, match.index ?? 0),
+    });
+  }
+  return links;
+}
+
+function splitHref(href) {
+  if (href.startsWith("<") && href.endsWith(">")) {
+    href = href.slice(1, -1);
+  }
+  const hashIndex = href.indexOf("#");
+  if (hashIndex === -1) return { target: href, fragment: "" };
+  return {
+    target: href.slice(0, hashIndex),
+    fragment: href.slice(hashIndex + 1),
+  };
+}
+
+async function main() {
+  const { root: rawRoot } = parseArgs(process.argv.slice(2));
+  const root = resolve(rawRoot);
+  const files = await listMarkdownFiles(root);
+  const markdownByFile = new Map();
+  const slugsByFile = new Map();
+  const failures = [];
+
+  for (const file of files) {
+    const markdown = await readFile(join(root, file), "utf8");
+    markdownByFile.set(file, markdown);
+    slugsByFile.set(file, headingSlugs(markdown));
+  }
+
+  for (const file of files) {
+    const markdown = markdownByFile.get(file);
+    for (const { href, line } of markdownLinks(markdown)) {
+      if (IGNORED_SCHEMES.test(href)) continue;
+      const { target, fragment } = splitHref(href);
+      if (!target && fragment) {
+        const decodedFragment = decodeURIComponent(fragment).toLowerCase();
+        if (!slugsByFile.get(file)?.has(decodedFragment)) {
+          failures.push(`${file}:${line} missing heading #${fragment}`);
+        }
+        continue;
+      }
+      if (/^[a-z][a-z0-9+.-]*:/i.test(target)) continue;
+
+      const withoutQuery = target.split("?")[0];
+      const resolvedTarget = resolve(
+        dirname(join(root, file)),
+        decodeURIComponent(withoutQuery),
+      );
+      if (!isInsideRoot(root, resolvedTarget)) continue;
+      if (!existsSync(resolvedTarget)) {
+        failures.push(`${file}:${line} missing target ${target}`);
+        continue;
+      }
+      if (
+        fragment &&
+        statSync(resolvedTarget).isFile() &&
+        resolvedTarget.endsWith(".md")
+      ) {
+        const relTarget = relative(root, resolvedTarget).split(sep).join("/");
+        const decodedFragment = decodeURIComponent(fragment).toLowerCase();
+        if (!slugsByFile.get(relTarget)?.has(decodedFragment)) {
+          failures.push(
+            `${file}:${line} missing heading ${target}#${fragment}`,
+          );
+        }
+      }
+    }
+  }
+
+  if (failures.length) {
+    console.error("Broken Markdown links found:");
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exit(1);
+  }
+
+  console.log(`Checked ${files.length} Markdown files.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/tests/markdown-links.test.mjs
+++ b/tests/markdown-links.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const checker = fileURLToPath(
+  new URL("../scripts/check-markdown-links.mjs", import.meta.url),
+);
+
+async function withFixture(run) {
+  const root = await mkdtemp(join(tmpdir(), "quickvoice-md-links-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function runChecker(root) {
+  return spawnSync(process.execPath, [checker, "--root", root], {
+    encoding: "utf8",
+  });
+}
+
+test("Markdown link checker accepts valid relative files and decoded headings", async () => {
+  await withFixture(async (root) => {
+    await writeFile(
+      join(root, "README.md"),
+      [
+        "# Home",
+        "",
+        "See [setup](./docs/setup.md#quick-start).",
+        "See [same file](#home).",
+        "Ignore [external](https://example.com) and ![inline](data:image/png;base64,AAAA).",
+      ].join("\n"),
+    );
+    await writeFile(join(root, "docs.md"), "# Standalone\n");
+    await mkdir(join(root, "docs"), { recursive: true });
+    await writeFile(join(root, "docs", "setup.md"), "# Quick Start\n");
+
+    const result = runChecker(root);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Checked 3 Markdown files\./);
+  });
+});
+
+test("Markdown link checker reports missing files with path and line", async () => {
+  await withFixture(async (root) => {
+    await writeFile(
+      join(root, "README.md"),
+      ["# Home", "", "See [missing](./docs/missing.md)."].join("\n"),
+    );
+
+    const result = runChecker(root);
+
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /README\.md:3 missing target \.\/docs\/missing\.md/,
+    );
+  });
+});
+
+test("Markdown link checker reports missing decoded heading fragments", async () => {
+  await withFixture(async (root) => {
+    await writeFile(
+      join(root, "README.md"),
+      ["# Home", "", "See [accent](./guide.md#caf%C3%A9-mode)."].join("\n"),
+    );
+    await writeFile(join(root, "guide.md"), "# Cafe Mode\n");
+
+    const result = runChecker(root);
+
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /README\.md:3 missing heading \.\/guide\.md#caf%C3%A9-mode/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `pnpm docs:links` for checking tracked Markdown files for broken relative links and heading fragments.
- Cover missing targets, decoded fragments, generated/vendor exclusions, and repo docs quirks with a focused Node test.
- List the command in contributor checks.

## Issue Or Context

- Related issue: Fixes #50
- First-time contributor?: yes
- Area changed: local tooling, docs

## Verification

- [x] I ran the narrowest check that proves this change.
- [ ] I ran `task doctor` when local tooling, env files, Docker services, or setup docs changed.
- [ ] I ran `pnpm ci:local` for shared code, CI, dependency, build, or release workflow changes, or documented the narrower check below.
- [x] Dependency changes are intentional, reflected in `pnpm-lock.yaml`, and any audit suppression changes include an expiry date.
- [x] UI screenshots or recordings are attached for product UI changes, or this PR has no product UI surface.
- [x] Environment changes are documented in the relevant `.env.*.example`, workflow variable notes, or README section.
- [x] I added broader checks if this touches shared code, auth, billing, database models, runtime agent behavior, or production UI.
- [x] For docs-only changes, I reviewed links, commands, and provider-credential boundaries.

Command or review evidence:

```sh
pnpm install --frozen-lockfile
node --test tests/markdown-links.test.mjs
pnpm docs:links
pnpm exec prettier --check scripts/check-markdown-links.mjs tests/markdown-links.test.mjs package.json CONTRIBUTING.md
node --test tests/*.test.mjs
```

## Launch And Positioning Guardrails

- [x] Public copy keeps the open-source Retell alternative story focused on control, self-hosting, privacy review, cost visibility, and extensibility.
- [x] Competitive comparisons explain tradeoffs without attacking competitors.
- [x] This PR does not invent screenshots, metrics, benchmarks, customers, compliance claims, provider partnerships, or production readiness claims.
- [x] Provider requirements are explicit when real calls, billing, OAuth, email, storage, or deployment need live credentials or product decisions.

## Screenshots Or Recordings

No product UI change.

## Maintainer Review Notes

- This is scoped to local docs tooling and tests only.
- `audit.md` and `ui_ux_audit.md` are excluded because they contain local absolute evidence paths from audits, not repository-relative documentation links.
- Generated/vendor-style directories such as `.claude`, `node_modules`, build outputs, and coverage are skipped explicitly.
