### PR TITLE
fix API key metadata creation

### DIFF
--- a/apps/console/src/app/(app)/settings/api-keys/page.tsx
+++ b/apps/console/src/app/(app)/settings/api-keys/page.tsx
@@ -48,9 +48,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import { PermissionMatrix } from "@/src/components/settings/PermissionMatrix";
 import { authClient } from "@/src/lib/auth-client";
-import { RESOURCES, type Permissions } from "@/src/lib/permissions";
 
 type ApiKey = {
   id: string;
@@ -61,18 +59,6 @@ type ApiKey = {
   enabled?: boolean | null;
   expiresAt?: string | Date | null;
 };
-
-const DEFAULT_API_KEY_PERMISSIONS = Object.fromEntries(
-  RESOURCES.map((resource) => [resource.id, [...resource.actions]]),
-) as Permissions;
-
-function normalizedPermissions(permissions: Permissions) {
-  return Object.fromEntries(
-    Object.entries(permissions).filter(
-      ([, actions]) => Array.isArray(actions) && actions.length > 0,
-    ),
-  ) as Record<string, string[]>;
-}
 
 const schema = z.object({
   name: z.string().min(2, "Name is required"),
@@ -90,9 +76,6 @@ export default function ApiKeysPage() {
   );
   const [creating, setCreating] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [permissions, setPermissions] = useState<Permissions>(
-    DEFAULT_API_KEY_PERMISSIONS,
-  );
 
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
@@ -105,11 +88,11 @@ export default function ApiKeysPage() {
     try {
       const api = authClient.apiKey as {
         list?: (input: {
-          query?: { referenceId?: string };
+          query?: { organizationId?: string };
         }) => Promise<{ data?: ApiKey[] }>;
       };
       if (api.list) {
-        const res = await api.list({ query: { referenceId: orgId } });
+        const res = await api.list({ query: { organizationId: orgId } });
         setKeys(res.data ?? []);
       }
     } catch (err) {
@@ -128,20 +111,10 @@ export default function ApiKeysPage() {
 
   async function onCreate(values: z.infer<typeof schema>) {
     if (!orgId) return;
-    const userId = session?.user?.id;
-    if (!userId) {
-      toast.error("Could not create key without an active user session");
-      return;
-    }
     setCreating(true);
     try {
       const api = authClient.apiKey as {
-        create?: (input: {
-          name: string;
-          referenceId: string;
-          metadata?: Record<string, unknown>;
-          permissions?: Record<string, string[]>;
-        }) => Promise<{
+        create?: (input: { name: string; organizationId: string }) => Promise<{
           data?: { key: string };
           error?: { message?: string };
         }>;
@@ -149,16 +122,13 @@ export default function ApiKeysPage() {
       if (!api.create) throw new Error("API key creation is not available");
       const { data, error } = await api.create({
         name: values.name,
-        referenceId: orgId,
-        metadata: { organizationId: orgId, userId },
-        permissions: normalizedPermissions(permissions),
+        organizationId: orgId,
       });
       if (error || !data?.key)
         throw new Error(error?.message ?? "Create failed");
       setNewKey({ key: data.key, name: values.name });
       setCreateOpen(false);
       form.reset();
-      setPermissions(DEFAULT_API_KEY_PERMISSIONS);
       await refresh();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not create key");
@@ -217,8 +187,8 @@ export default function ApiKeysPage() {
                 <DialogTitle>Create API key</DialogTitle>
                 <DialogDescription>
                   Give the key a descriptive name. You&apos;ll be able to copy
-                  it once — make sure to store it somewhere safe. The default
-                  permissions are MCP-ready and can be narrowed below.
+                  it once — make sure to store it somewhere safe. New keys are
+                  organization-scoped and MCP-ready by default.
                 </DialogDescription>
               </DialogHeader>
               <Form {...form}>
@@ -239,21 +209,6 @@ export default function ApiKeysPage() {
                       </FormItem>
                     )}
                   />
-                  <div className="space-y-2">
-                    <div>
-                      <p className="text-sm font-medium">Permissions</p>
-                      <p className="text-xs text-muted-foreground">
-                        MCP tools and API routes require explicit permissions.
-                        Leave the default full-access matrix for trusted
-                        automation, or remove actions for least-privilege keys.
-                      </p>
-                    </div>
-                    <PermissionMatrix
-                      value={permissions}
-                      onChange={setPermissions}
-                      disabled={creating}
-                    />
-                  </div>
                   <DialogFooter>
                     <Button
                       type="button"

--- a/apps/console/tests/audit-fixes.test.mjs
+++ b/apps/console/tests/audit-fixes.test.mjs
@@ -221,6 +221,23 @@ test("server API key plugin grants organization-scoped default permissions", () 
   );
 });
 
+test("MCP setup UI asks for QuickVoice API keys and renders x-api-key config", () => {
+  const generator = read("../docs/src/components/mcp/mcp-config-generator.tsx");
+  const config = read("../docs/src/lib/mcp-config.ts");
+
+  assert.match(generator, /QuickVoice API key/);
+  assert.match(
+    generator,
+    /The API key is only used to render the config below/,
+  );
+  assert.match(
+    config,
+    /"x-api-key": apiKey\.trim\(\) \|\| "YOUR_QUICKVOICE_API_KEY"/,
+  );
+  assert.doesNotMatch(generator, /MCP token|The token is only used/);
+  assert.doesNotMatch(config, /Authorization|Bearer|YOUR_QUICKVOICE_MCP_TOKEN/);
+});
+
 test("agent creation, limits, and deletion are wired", () => {
   const agentsTable = read("src/components/agents/AgentsTable.tsx");
   assert.match(

--- a/apps/console/tests/audit-fixes.test.mjs
+++ b/apps/console/tests/audit-fixes.test.mjs
@@ -199,17 +199,26 @@ test("google oauth redirects back to the canonical console origin", () => {
   assert.doesNotMatch(links, /callbackURL:\s*["'`]\/dashboard["'`]/);
 });
 
-test("console API key creation grants explicit MCP-ready route permissions", () => {
+test("console API key creation uses organization keys without client-only fields", () => {
   const page = read("src/app/(app)/settings/api-keys/page.tsx");
-  const permissions = read("src/lib/permissions.ts");
 
-  assert.match(permissions, /agentWidget/);
-  assert.match(page, /DEFAULT_API_KEY_PERMISSIONS/);
-  assert.match(page, /PermissionMatrix/);
-  assert.match(page, /permissions:\s*normalizedPermissions\(permissions\)/);
+  assert.match(page, /organizationId:\s*orgId/);
   assert.match(page, /MCP-ready/);
   assert.match(page, /x-api-key/);
+  assert.doesNotMatch(page, /metadata:\s*\{ organizationId/);
+  assert.doesNotMatch(page, /permissions:\s*normalizedPermissions/);
   assert.doesNotMatch(page, /Do not send them as bearer tokens/);
+});
+
+test("server API key plugin grants organization-scoped default permissions", () => {
+  const source = read("../server/src/lib/auth.ts");
+
+  assert.match(source, /references:\s*"organization"/);
+  assert.match(source, /defaultPermissions:\s*apiKeyDefaultPermissions/);
+  assert.match(
+    source,
+    /agentWidget:\s*\["create", "read", "update", "delete"\]/,
+  );
 });
 
 test("agent creation, limits, and deletion are wired", () => {

--- a/apps/docs/src/app/mcp/api-keys/page.tsx
+++ b/apps/docs/src/app/mcp/api-keys/page.tsx
@@ -17,8 +17,8 @@ export default function ApiKeysPage() {
             Go to <strong>Settings → API keys</strong>.
           </li>
           <li>
-            Create a new key and choose the permissions your MCP client needs.
-            The default matrix is MCP-ready for trusted automation.
+            Create a new key. New keys are organization-scoped and MCP-ready by
+            default for trusted automation.
           </li>
           <li>Copy the key once and store it in your secret manager.</li>
         </ol>

--- a/apps/docs/src/components/mcp/mcp-config-generator.tsx
+++ b/apps/docs/src/components/mcp/mcp-config-generator.tsx
@@ -80,7 +80,7 @@ export function McpConfigGenerator() {
                   </button>
                 </div>
                 <span className="mt-2 block text-xs leading-5 text-[var(--qv-muted)]">
-                  The token is only used to render the config below.
+                  The API key is only used to render the config below.
                 </span>
               </label>
 

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -9,6 +9,7 @@ import prisma from "../config/prisma.js";
 import { stripeClient } from "../config/stripe.js";
 import { sendEmail } from "./mailer.js";
 import { ac, roles } from "./permissions.js";
+
 import { plans } from "../../data/plans.js";
 import {
   isSecureServerUrl,
@@ -16,6 +17,19 @@ import {
   trustedOrigins,
 } from "../config/origins.js";
 import { cleanupOrganizationBeforeDeletion } from "../modules/organization/organization-cleanup.service.js";
+
+const apiKeyDefaultPermissions = {
+  agent: ["create", "read", "update", "delete"],
+  agentConfiguration: ["create", "read", "update", "delete"],
+  agentWidget: ["create", "read", "update", "delete"],
+  phoneNumber: ["create", "read", "update", "delete"],
+  knowledgeSource: ["create", "read", "update", "delete"],
+  callLogs: ["read", "delete"],
+  outboundCalls: ["create", "read", "delete"],
+  campaigns: ["create", "read", "delete"],
+  tools: ["create", "read", "update", "delete"],
+  secrets: ["create", "read", "delete"],
+};
 
 // ─── Better Auth server instance ────────────────────────────────────────────
 export const auth = betterAuth({
@@ -64,6 +78,10 @@ export const auth = betterAuth({
     admin(),
     apiKey({
       enableSessionForAPIKeys: true,
+      references: "organization",
+      permissions: {
+        defaultPermissions: apiKeyDefaultPermissions,
+      },
     }),
     organization({
       ac,
@@ -82,16 +100,13 @@ export const auth = betterAuth({
                   : null,
             });
           } catch (error) {
-            console.error(
-              "[organization] external cleanup blocked deletion",
-              {
-                organizationId: org.id,
-                error:
-                  error instanceof Error
-                    ? error.message
-                    : "Unknown cleanup error",
-              },
-            );
+            console.error("[organization] external cleanup blocked deletion", {
+              organizationId: org.id,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Unknown cleanup error",
+            });
             throw new APIError("BAD_REQUEST", {
               message:
                 "Organization cleanup failed. No database deletion was performed; retry after checking provider connectivity.",


### PR DESCRIPTION
## Summary
- stop sending API-key `metadata` and client-side `permissions` from the console create-key flow
- create/list organization-scoped Better Auth API keys with `organizationId`
- configure server-side API key defaults with organization references and MCP-ready permissions
- update the MCP connect/setup UI copy so it asks for a QuickVoice API key, not an MCP token
- ensure the generated MCP client config uses the canonical `x-api-key` header instead of `Authorization: Bearer ...`
- add regression coverage for the client payload, server plugin config, and MCP setup UI/config text

## Root cause
Better Auth's API key plugin disables metadata by default, so the console request that included `metadata: { organizationId, userId }` failed with `Metadata is disabled`. The same browser flow was also trying to send `permissions`, which Better Auth treats as a server-only property.

Separately, the MCP setup UI had stale token wording from the older MCP auth design. QuickVoice now creates organization-scoped API keys, so the UI and generated client config should consistently say API key and use `x-api-key`.

## Validation
- `pnpm exec prettier --check apps/server/src/lib/auth.ts 'apps/console/src/app/(app)/settings/api-keys/page.tsx' apps/console/tests/audit-fixes.test.mjs`
- `node --test apps/console/tests/audit-fixes.test.mjs`
- `pnpm --filter server exec tsx --test tests/middleware/authorize.middleware.test.ts`
- `pnpm --filter console check-types`
- `pnpm exec prettier --check apps/docs/src/components/mcp/mcp-config-generator.tsx apps/docs/src/app/mcp/api-keys/page.tsx apps/console/tests/audit-fixes.test.mjs`
- `pnpm --filter docs check-types`
- `pnpm --filter docs lint`

Note: `pnpm --filter server check-types` / server lint still fail on the pre-existing Prisma `KnowledgeSource.errorCode` generated type mismatch in `src/modules/kb/kb.repository.ts`, unrelated to this API-key/MCP UI fix.
