### PR TITLE
fix API key list rendering

### DIFF
--- a/apps/console/src/app/(app)/settings/api-keys/page.tsx
+++ b/apps/console/src/app/(app)/settings/api-keys/page.tsx
@@ -60,6 +60,11 @@ type ApiKey = {
   expiresAt?: string | Date | null;
 };
 
+type ApiKeyListResponse = {
+  apiKeys?: ApiKey[];
+  total?: number;
+};
+
 const schema = z.object({
   name: z.string().min(2, "Name is required"),
 });
@@ -83,17 +88,21 @@ export default function ApiKeysPage() {
   });
 
   async function refresh() {
-    if (!orgId) return;
+    if (!orgId) {
+      setKeys([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     try {
       const api = authClient.apiKey as {
         list?: (input: {
           query?: { organizationId?: string };
-        }) => Promise<{ data?: ApiKey[] }>;
+        }) => Promise<{ data?: ApiKeyListResponse }>;
       };
       if (api.list) {
         const res = await api.list({ query: { organizationId: orgId } });
-        setKeys(res.data ?? []);
+        setKeys(res.data?.apiKeys ?? []);
       }
     } catch (err) {
       toast.error(

--- a/apps/console/tests/audit-fixes.test.mjs
+++ b/apps/console/tests/audit-fixes.test.mjs
@@ -203,6 +203,9 @@ test("console API key creation uses organization keys without client-only fields
   const page = read("src/app/(app)/settings/api-keys/page.tsx");
 
   assert.match(page, /organizationId:\s*orgId/);
+  assert.match(page, /ApiKeyListResponse/);
+  assert.match(page, /setKeys\(res\.data\?\.apiKeys \?\? \[\]\)/);
+  assert.doesNotMatch(page, /setKeys\(res\.data \?\? \[\]\)/);
   assert.match(page, /MCP-ready/);
   assert.match(page, /x-api-key/);
   assert.doesNotMatch(page, /metadata:\s*\{ organizationId/);


### PR DESCRIPTION
## Summary
- fix the API keys page to read Better Auth's list response from `data.apiKeys`
- keep empty/loading state correct when no active organization is available
- add regression coverage so the UI does not treat `apiKey.list()` data as an array again

## Root cause
Better Auth `authClient.apiKey.list()` returns an object shaped like `{ apiKeys, total, limit, offset }`. The console page was doing `setKeys(res.data ?? [])`, so after a successful create/list response the React state received the wrapper object instead of the key array. Because that object has no `.length`, the page kept rendering the “No API keys yet” empty state.

## Validation
- `pnpm exec prettier --check 'apps/console/src/app/(app)/settings/api-keys/page.tsx' apps/console/tests/audit-fixes.test.mjs`
- `node --test apps/console/tests/audit-fixes.test.mjs`
- `pnpm --filter console check-types`
- `pnpm --filter console lint`
