### PR TITLE
fix LiveKit preemptive generation crash

### DIFF
--- a/apps/ai/main.py
+++ b/apps/ai/main.py
@@ -511,7 +511,6 @@ async def entrypoint(ctx: JobContext):
         vad=silero.VAD.load(),
         turn_handling=TurnHandlingOptions(
             turn_detection=inference.TurnDetector(),
-            preemptive_generation=config.get("preemptive_generation", True),
         ),
         ivr_detection=config["ivr_navigation_enabled"],
     )

--- a/apps/ai/tests/test_livekit_turn_handling.py
+++ b/apps/ai/tests/test_livekit_turn_handling.py
@@ -1,0 +1,49 @@
+import ast
+import os
+import unittest
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MAIN_PATH = os.path.join(ROOT, "main.py")
+
+
+class LiveKitTurnHandlingTests(unittest.TestCase):
+    def test_agent_session_turn_handling_does_not_pass_boolean_preemptive_generation(self):
+        with open(MAIN_PATH, encoding="utf-8") as source:
+            tree = ast.parse(source.read(), filename=MAIN_PATH)
+
+        agent_sessions = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "AgentSession"
+        ]
+
+        self.assertGreaterEqual(len(agent_sessions), 1)
+
+        for session_call in agent_sessions:
+            turn_handling = next(
+                (
+                    keyword.value
+                    for keyword in session_call.keywords
+                    if keyword.arg == "turn_handling"
+                ),
+                None,
+            )
+            self.assertIsNotNone(turn_handling)
+            self.assertIsInstance(turn_handling, ast.Call)
+            self.assertIsInstance(turn_handling.func, ast.Name)
+            self.assertEqual(turn_handling.func.id, "TurnHandlingOptions")
+
+            option_names = {
+                keyword.arg
+                for keyword in turn_handling.keywords
+                if keyword.arg is not None
+            }
+            self.assertIn("turn_detection", option_names)
+            self.assertNotIn("preemptive_generation", option_names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stop passing the deprecated boolean `preemptive_generation` value into LiveKit `TurnHandlingOptions`
- align AI worker session creation with current LiveKit Agents Python SDK docs
- add a regression test so `AgentSession` turn handling cannot reintroduce the boolean option

## Root cause
Outbound calls were reaching LiveKit/SIP, but the AI worker crashed while constructing `AgentSession`. Newer LiveKit Agents 1.x treats `preemptive_generation` as an options mapping, while QuickVoice passed a boolean from config. That produced `TypeError: 'bool' object is not a mapping`, so the worker exited before joining the room, speaking the first message, publishing live transcript updates, or finalizing call logs.

## Validation
- `python3 -m py_compile apps/ai/main.py apps/ai/tests/test_livekit_turn_handling.py`
- `python3 -m unittest apps/ai/tests/test_livekit_turn_handling.py`
- `python3 -m unittest apps/ai/tests/test_config_handler.py`
- `git diff --check`
