### PR TITLE
fix outbound live call identity

### DIFF
--- a/apps/ai/handlers/worker_handler.py
+++ b/apps/ai/handlers/worker_handler.py
@@ -68,11 +68,26 @@ def build_call_context(room_name: str, metadata: dict[str, Any]) -> dict[str, An
     )
     direction = _pick(metadata, "direction", "callDirection") or "inbound"
 
+    room_outbound_id = _outbound_id_from_room(room_name)
+    outbound_id = _pick(metadata, "outbound_id", "outboundId") or room_outbound_id
+
     if direction == "outbound":
-        agent_number = _pick(metadata, "agent_number", "agentNumber", "from_number", "fromNumber") or room_agent_number
-        user_number = _pick(metadata, "user_number", "userNumber", "to_number", "toNumber") or room_user_number
+        agent_number = (
+            _pick(metadata, "agent_number", "agentNumber", "from_number", "fromNumber")
+            or room_agent_number
+        )
+        user_number = (
+            _pick(metadata, "user_number", "userNumber", "to_number", "toNumber")
+            or room_user_number
+        )
         from_number = agent_number
         to_number = user_number
+        call_id = (
+            _pick(metadata, "call_id", "callId")
+            or outbound_id
+            or _pick(metadata, "sip.callID", "sip_call_id")
+            or room_name
+        )
     else:
         agent_number = _pick(
             metadata,
@@ -96,16 +111,24 @@ def build_call_context(room_name: str, metadata: dict[str, Any]) -> dict[str, An
         ) or room_user_number
         from_number = user_number
         to_number = agent_number
+        call_id = (
+            _pick(metadata, "call_id", "callId", "sip.callID", "sip_call_id")
+            or room_name
+        )
 
     return {
-        "call_id": _pick(metadata, "call_id", "callId", "sip.callID", "sip_call_id") or room_name,
+        "call_id": call_id,
         "agent_id": _pick(metadata, "agent_id", "agentId"),
         "agent_number": agent_number,
         "user_number": user_number,
         "direction": direction,
         "from_number": from_number,
         "to_number": to_number,
-        "outbound_id": _pick(metadata, "outbound_id", "outboundId"),
+        "outbound_id": (
+            outbound_id
+            if direction == "outbound"
+            else _pick(metadata, "outbound_id", "outboundId")
+        ),
         "provider": _pick(metadata, "provider"),
         "metadata": _metadata_extras(metadata),
     }
@@ -485,6 +508,13 @@ def _numbers_from_room(room_name: str):
     if len(parts) == 2:
         return parts[0], parts[1]
     return None, None
+
+
+def _outbound_id_from_room(room_name: str):
+    if room_name.startswith("outbound_"):
+        outbound_id = room_name[len("outbound_") :].strip()
+        return outbound_id or None
+    return None
 
 
 def _pick(source: dict[str, Any], *keys: str):

--- a/apps/ai/tests/test_worker_helpers.py
+++ b/apps/ai/tests/test_worker_helpers.py
@@ -179,6 +179,7 @@ class WorkerHandlerTests(unittest.TestCase):
                 "from_number": "+15551230000",
                 "to_number": "+15550001111",
                 "outbound_id": "2b1f6d53-42f5-4cc7-9689-7b6f51a0c113",
+                "sip.callID": "carrier-call-id-123",
             },
         )
 
@@ -187,7 +188,22 @@ class WorkerHandlerTests(unittest.TestCase):
         self.assertEqual(context["user_number"], "+15550001111")
         self.assertEqual(context["from_number"], "+15551230000")
         self.assertEqual(context["to_number"], "+15550001111")
+        self.assertEqual(context["call_id"], "2b1f6d53-42f5-4cc7-9689-7b6f51a0c113")
         self.assertEqual(context["outbound_id"], "2b1f6d53-42f5-4cc7-9689-7b6f51a0c113")
+
+    def test_build_call_context_uses_outbound_room_id_before_carrier_call_id(self):
+        context = build_call_context(
+            room_name="outbound_9b1c1f91-c050-444b-a1f1-d9b719e542c1",
+            metadata={
+                "direction": "outbound",
+                "from_number": "+15551230000",
+                "to_number": "+15550001111",
+                "sip.callID": "carrier-call-id-123",
+            },
+        )
+
+        self.assertEqual(context["call_id"], "9b1c1f91-c050-444b-a1f1-d9b719e542c1")
+        self.assertEqual(context["outbound_id"], "9b1c1f91-c050-444b-a1f1-d9b719e542c1")
 
     def test_build_call_context_keeps_web_widget_room_out_of_phone_fields(self):
         context = build_call_context(

--- a/apps/console/src/components/calls/LiveCallsDock.tsx
+++ b/apps/console/src/components/calls/LiveCallsDock.tsx
@@ -455,7 +455,11 @@ export function LiveCallsDock({ organizationId }: { organizationId: string }) {
 
   useEffect(() => {
     if (!selectedCall) return;
-    const updated = sortedCalls.find((call) => call.callId === selectedCall.callId);
+    const updated = sortedCalls.find(
+      (call) =>
+        call.callId === selectedCall.callId ||
+        call.roomName === selectedCall.roomName
+    );
     if (updated && updated !== selectedCall) setSelectedCall(updated);
     // Updating metadata should follow query-cache changes without closing an ended call.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -621,14 +625,18 @@ export function LiveCallsDock({ organizationId }: { organizationId: string }) {
 }
 
 function dedupeLiveCalls(calls: LiveCallRoom[]) {
-  const byCallId = new Map<string, LiveCallRoom>();
+  const merged: LiveCallRoom[] = [];
   for (const call of calls) {
-    const existing = byCallId.get(call.callId);
-    if (!existing) {
-      byCallId.set(call.callId, call);
+    const existingIndex = merged.findIndex(
+      (existing) =>
+        existing.callId === call.callId || existing.roomName === call.roomName
+    );
+    if (existingIndex === -1) {
+      merged.push(call);
       continue;
     }
-    byCallId.set(call.callId, {
+    const existing = merged[existingIndex]!;
+    merged[existingIndex] = {
       ...existing,
       participantCount: Math.max(existing.participantCount, call.participantCount),
       direction: existing.direction === "unknown" ? call.direction : existing.direction,
@@ -639,7 +647,7 @@ function dedupeLiveCalls(calls: LiveCallRoom[]) {
       calleeId: existing.calleeId ?? call.calleeId,
       fromNumber: existing.fromNumber ?? call.fromNumber,
       toNumber: existing.toNumber ?? call.toNumber,
-    });
+    };
   }
-  return [...byCallId.values()];
+  return merged;
 }

--- a/apps/console/src/providers/live-calls-provider.tsx
+++ b/apps/console/src/providers/live-calls-provider.tsx
@@ -49,7 +49,9 @@ const LiveCallsContext = createContext<LiveCallsContextValue | null>(null);
 
 function upsertCall(current: LiveCallRoom[] | undefined, call: LiveCallRoom) {
   const existing = current ?? [];
-  const index = existing.findIndex((item) => item.callId === call.callId);
+  const index = existing.findIndex(
+    (item) => item.callId === call.callId || item.roomName === call.roomName
+  );
   if (index === -1) return [call, ...existing];
   const next = [...existing];
   next[index] = { ...next[index], ...call };
@@ -125,7 +127,11 @@ export function LiveCallsProvider({
       if (!isLifecycleEventForOrganization(event, organizationId)) return;
       queryClient.setQueryData<LiveCallRoom[]>(
         queryKeys.calls.live(),
-        (current) => current?.filter((call) => call.callId !== event.callId) ?? []
+        (current) =>
+          current?.filter(
+            (call) =>
+              call.callId !== event.callId && call.roomName !== event.roomName
+          ) ?? []
       );
       setEndedCallIds((current) => new Set(current).add(event.callId));
     }

--- a/apps/console/tests/live-transcript.test.mjs
+++ b/apps/console/tests/live-transcript.test.mjs
@@ -24,6 +24,14 @@ test("socket events update only the authenticated organization cache", () => {
   assert.match(provider, /"live-call:started"/);
   assert.match(provider, /"live-call:updated"/);
   assert.match(provider, /"live-call:ended"/);
+  assert.match(
+    provider,
+    /item\.callId === call\.callId \|\| item\.roomName === call\.roomName/
+  );
+  assert.match(
+    provider,
+    /call\.callId !== event\.callId && call\.roomName !== event\.roomName/
+  );
 });
 
 test("watching a call replays, validates, deduplicates, and unwatches transcripts", () => {
@@ -58,6 +66,11 @@ test("live transcript UI restores selection and preserves reader scroll position
   assert.match(dock, /canEndCall && !transcript\.isEnded/);
   assert.match(dock, /fromNumber/);
   assert.match(dock, /toNumber/);
+  assert.match(
+    dock,
+    /existing\.callId === call\.callId \|\| existing\.roomName === call\.roomName/
+  );
+  assert.match(dock, /call\.roomName === selectedCall\.roomName/);
 });
 
 test("console declares the matching Socket.IO client dependency", () => {


### PR DESCRIPTION
## Summary
- make outbound AI call context use the QuickVoice outbound id/room id before carrier SIP call ids
- merge live-call socket and REST/fallback entries by `roomName` as well as `callId`
- remove same-room stale duplicates when a live-call ended event arrives
- send the initial outbound greeting as non-interruptible to avoid the agent hearing its own greeting as caller speech
- suppress recent agent transcript fragments when they arrive back as final caller transcripts
- add regression coverage for outbound identity, live-call UI dedupe, and transcript self-echo handling

## Root cause
Outbound calls can have two identities at the same time: the QuickVoice outbound id from `outbound_<id>` rooms, and a carrier/LiveKit SIP call id such as `sip.callID`. The AI live transcript publisher could register the carrier id while LiveKit room fallback used the outbound room id. The console cache only deduped and removed calls by `callId`, so one phone call could appear as two live calls and one stale room could remain after hangup.

After that was resolved, the first greeting could still be treated as interruptible. If telephony echo or caller speakerphone leaked the agent's audio back into STT, the session could treat phrases from the agent's own greeting as caller input. LiveKit examples use non-interruptible opening greetings, and the transcript collector now also drops recent agent text fragments if they reappear as caller transcript.

## Validation
- `python3 -m py_compile apps/ai/handlers/worker_handler.py apps/ai/handlers/transcript_collector.py apps/ai/tests/test_transcript_collector.py`
- `PYTHONPATH=apps/ai python3 -m unittest apps/ai/tests/test_transcript_collector.py`
- lightweight outbound identity check via `PYTHONPATH=apps/ai python3 ... build_call_context(...)`
- lightweight first-message interruption check via `PYTHONPATH=apps/ai python3 ... speak_first_message(...)`
- `node --test apps/console/tests/live-transcript.test.mjs`
- `git diff --check`

Note: `python3 -m unittest apps/ai/tests/test_worker_helpers.py` is blocked in this container because the LiveKit Python package is not installed (`ModuleNotFoundError: No module named 'livekit'`).
