### PR TITLE
prevent outbound greeting self echo

### DIFF
--- a/apps/ai/handlers/transcript_collector.py
+++ b/apps/ai/handlers/transcript_collector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -15,6 +16,7 @@ class TranscriptCollector:
         self._items: list[dict[str, Any]] = []
         self._seen_ids: set[str] = set()
         self._last_final_user_transcript: str | None = None
+        self._recent_agent_transcripts: list[str] = []
         self._on_item = on_item
 
     def attach(self, session: Any) -> "TranscriptCollector":
@@ -37,6 +39,8 @@ class TranscriptCollector:
             content = getattr(item, "content", "")
         text = _content_to_text(content)
         if not text:
+            return
+        if role == "user" and self._looks_like_agent_echo(text):
             return
 
         message_id = str(getattr(item, "id", "") or f"msg-{len(self._items)}")
@@ -67,6 +71,8 @@ class TranscriptCollector:
         if not text or text == self._last_final_user_transcript:
             return
         self._last_final_user_transcript = text
+        if self._looks_like_agent_echo(text):
+            return
 
         # Most final user turns also arrive through conversation_item_added.
         # Keep this as a fallback for STT events that are not materialized into
@@ -105,6 +111,8 @@ class TranscriptCollector:
         return list(self._items)
 
     def _append(self, item: dict[str, Any]) -> None:
+        if item.get("role") == "agent":
+            self._remember_agent_transcript(str(item.get("content") or ""))
         self._items.append(item)
         if self._on_item is None:
             return
@@ -114,6 +122,27 @@ class TranscriptCollector:
             # Live monitoring is optional and must never break transcript
             # collection or the voice session.
             return
+
+    def _remember_agent_transcript(self, text: str) -> None:
+        normalized = _normalize_text(text)
+        if len(normalized) < 12:
+            return
+        if (
+            self._recent_agent_transcripts
+            and self._recent_agent_transcripts[-1] == normalized
+        ):
+            return
+        self._recent_agent_transcripts.append(normalized)
+        del self._recent_agent_transcripts[:-5]
+
+    def _looks_like_agent_echo(self, text: str) -> bool:
+        normalized = _normalize_text(text)
+        if len(normalized) < 12 or len(normalized.split()) < 3:
+            return False
+        return any(
+            normalized in agent_text
+            for agent_text in self._recent_agent_transcripts[-5:]
+        )
 
     def _replace_matching_synthetic_turn(
         self,
@@ -149,4 +178,4 @@ def _content_to_text(content: Any) -> str:
 
 
 def _normalize_text(value: Any) -> str:
-    return " ".join(str(value or "").split()).casefold()
+    return " ".join(re.findall(r"\w+", str(value or "").casefold()))

--- a/apps/ai/handlers/worker_handler.py
+++ b/apps/ai/handlers/worker_handler.py
@@ -436,7 +436,7 @@ def speak_first_message(session: Any, config: dict[str, Any]):
     first_message = (config.get("first_message") or "").strip()
     if not first_message:
         return None
-    return session.say(first_message, allow_interruptions=True)
+    return session.say(first_message, allow_interruptions=False)
 
 
 def parse_preview_user_transcript_packet(

--- a/apps/ai/tests/test_transcript_collector.py
+++ b/apps/ai/tests/test_transcript_collector.py
@@ -94,6 +94,53 @@ class TranscriptCollectorTests(unittest.TestCase):
         self.assertEqual(collector.read()[0]["id"], "agent-committed-1")
         self.assertEqual(len(published), 1)
 
+    def test_user_stt_fallback_ignores_recent_agent_echo_fragment(self):
+        collector = TranscriptCollector()
+        collector.on_conversation_item_added(
+            SimpleNamespace(
+                created_at=1704067201.0,
+                item=SimpleNamespace(
+                    id="assistant-1",
+                    role="assistant",
+                    text_content=(
+                        "Hi, thanks for calling, I can help answer questions, "
+                        "capture details, or route the next step."
+                    ),
+                    created_at=1704067201.0,
+                ),
+            )
+        )
+        collector.on_user_input_transcribed(
+            SimpleNamespace(
+                transcript="Questions capture details or",
+                is_final=True,
+                created_at=1704067202.0,
+            )
+        )
+
+        self.assertEqual(len(collector.read()), 1)
+        self.assertEqual(collector.read()[0]["role"], "agent")
+
+    def test_committed_user_item_ignores_recent_agent_echo_fragment(self):
+        collector = TranscriptCollector()
+        collector.on_agent_transcription_final(
+            "I'm here to assist you.", time=1704067201.0
+        )
+        collector.on_conversation_item_added(
+            SimpleNamespace(
+                created_at=1704067202.0,
+                item=SimpleNamespace(
+                    id="user-echo-1",
+                    role="user",
+                    text_content="I'm here to assist you.",
+                    created_at=1704067202.0,
+                ),
+            )
+        )
+
+        self.assertEqual(len(collector.read()), 1)
+        self.assertEqual(collector.read()[0]["role"], "agent")
+
     def test_notifies_live_publisher_only_for_new_final_items(self):
         published = []
         collector = TranscriptCollector(on_item=published.append)

--- a/apps/ai/tests/test_worker_helpers.py
+++ b/apps/ai/tests/test_worker_helpers.py
@@ -256,7 +256,7 @@ class WorkerHandlerTests(unittest.TestCase):
         result = speak_first_message(session, {"first_message": "Hello caller."})
 
         self.assertEqual(result, "speech-handle")
-        self.assertEqual(session.calls, [("Hello caller.", {"allow_interruptions": True})])
+        self.assertEqual(session.calls, [("Hello caller.", {"allow_interruptions": False})])
 
     def test_parse_preview_user_transcript_packet_accepts_preview_user_text(self):
         text = parse_preview_user_transcript_packet(


### PR DESCRIPTION
## Summary
- send the initial outbound greeting as non-interruptible so LiveKit discards buffered caller audio while the agent is speaking
- suppress recent agent transcript fragments if they are later emitted as final caller transcripts
- add regression coverage for the screenshot case where caller transcript contains pieces of the agent greeting/response

## Root cause
The outbound greeting was played with `allow_interruptions=True`. If telephony echo or caller speakerphone leaked the agent's audio back into STT, LiveKit could treat the agent's own speech as caller input. That showed up as caller bubbles like "Questions capture details or" and could make the agent respond to itself.

LiveKit examples use non-interruptible opening greetings. Keeping the first message uninterruptible lets LiveKit drop buffered audio during that greeting. The transcript collector now also filters recent agent text fragments from caller transcript as a safety net for live transcript and call-log output.

## Validation
- `python3 -m py_compile apps/ai/handlers/worker_handler.py apps/ai/handlers/transcript_collector.py apps/ai/tests/test_transcript_collector.py`
- `PYTHONPATH=apps/ai python3 -m unittest apps/ai/tests/test_transcript_collector.py`
- lightweight first-message interruption check via `PYTHONPATH=apps/ai python3 ... speak_first_message(...)`
- `git diff --check`
