### PR TITLE
Align docs theme and API reference

### DIFF
--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -3,28 +3,28 @@
 
 :root {
   color-scheme: dark;
-  --qv-blue: #6ea8ff;
-  --qv-blue-ink: #9dc2ff;
-  --qv-bg: #070a12;
-  --qv-bg-muted: #0d1320;
-  --qv-ink: #f8fafc;
-  --qv-muted: #a8b3c5;
-  --qv-border: rgba(148, 163, 184, 0.22);
-  --qv-card: #0b1020;
-  --qv-card-soft: #111827;
-  --qv-code: #050816;
-  --qv-shadow: rgba(0, 0, 0, 0.36);
+  --qv-blue: #8b5cf6;
+  --qv-blue-ink: #a855f7;
+  --qv-bg: #000000;
+  --qv-bg-muted: #1a1a1a;
+  --qv-ink: #ffffff;
+  --qv-muted: #94a3b8;
+  --qv-border: #262626;
+  --qv-card: #0a0a0a;
+  --qv-card-soft: #1a1a1a;
+  --qv-code: #0b0b0f;
+  --qv-shadow: rgba(0, 0, 0, 0.45);
 }
 
 :root[data-theme="light"] {
   color-scheme: light;
-  --qv-blue: #002fa7;
-  --qv-blue-ink: #001f70;
+  --qv-blue: #2563eb;
+  --qv-blue-ink: #1d4ed8;
   --qv-bg: #ffffff;
-  --qv-bg-muted: #f7f7f8;
+  --qv-bg-muted: #f1f5f9;
   --qv-ink: #0f172a;
-  --qv-muted: #5f6b7a;
-  --qv-border: #dfe3ea;
+  --qv-muted: #64748b;
+  --qv-border: #e2e8f0;
   --qv-card: #ffffff;
   --qv-card-soft: #f8fafc;
   --qv-code: #0b1220;
@@ -56,8 +56,9 @@ body {
   background-image:
     linear-gradient(to right, color-mix(in srgb, var(--qv-border) 64%, transparent) 1px, transparent 1px),
     linear-gradient(to bottom, color-mix(in srgb, var(--qv-border) 64%, transparent) 1px, transparent 1px),
-    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--qv-blue) 13%, transparent), transparent 34rem);
-  background-size: 40px 40px, 40px 40px, auto;
+    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--qv-blue) 18%, transparent), transparent 34rem),
+    radial-gradient(circle at 82% 18%, color-mix(in srgb, var(--qv-blue-ink) 10%, transparent), transparent 28rem);
+  background-size: 40px 40px, 40px 40px, auto, auto;
 }
 
 .prose-qv {
@@ -121,6 +122,19 @@ body {
 }
 .ring-\[var\(--qv-border\)\] {
   --tw-ring-color: var(--qv-border) !important;
+}
+
+.text-\[\#002FA7\] {
+  color: var(--qv-blue) !important;
+}
+.bg-\[\#002FA7\] {
+  background-color: var(--qv-blue) !important;
+}
+.border-\[\#002FA7\] {
+  border-color: var(--qv-blue) !important;
+}
+.hover\:bg-\[\#001f70\]:hover {
+  background-color: var(--qv-blue-ink) !important;
 }
 
 :root[data-theme="dark"] .hover\:bg-white:hover {
@@ -197,6 +211,7 @@ body {
   --scalar-color-3: color-mix(in srgb, var(--qv-muted) 78%, transparent) !important;
   --scalar-border-color: var(--qv-border) !important;
   --scalar-accent: var(--qv-blue) !important;
+  --scalar-color-accent: var(--qv-blue) !important;
   --scalar-sidebar-background-1: var(--qv-card) !important;
   --scalar-sidebar-background-2: var(--qv-card-soft) !important;
   --scalar-sidebar-color-1: var(--qv-ink) !important;

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <head>
         <script
           dangerouslySetInnerHTML={{

--- a/apps/docs/src/components/api/api-reference.tsx
+++ b/apps/docs/src/components/api/api-reference.tsx
@@ -10,6 +10,7 @@ import {
   ShieldCheck,
 } from "lucide-react";
 import { McpCopyButton } from "@/components/mcp/mcp-copy-button";
+import { QuickVoiceLogo } from "@/components/quickvoice-logo";
 import {
   apiAuthNotes,
   apiBaseUrl,
@@ -32,17 +33,14 @@ const methodClass: Record<ApiMethod, string> = {
 
 export function ApiReference() {
   return (
-    <main className="api-reference-surface min-h-screen bg-[#070a12] text-slate-100">
-      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_20%_0%,rgba(0,47,167,0.28),transparent_32rem),radial-gradient(circle_at_85%_20%,rgba(14,165,233,0.12),transparent_28rem)]" />
+    <main className="api-reference-surface min-h-screen bg-[var(--qv-bg)] text-slate-100">
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_20%_0%,color-mix(in_srgb,var(--qv-blue)_24%,transparent),transparent_32rem),radial-gradient(circle_at_85%_20%,color-mix(in_srgb,var(--qv-blue-ink)_12%,transparent),transparent_28rem)]" />
       <div className="relative mx-auto grid max-w-[1500px] grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)]">
-        <aside className="hidden min-h-dvh border-r border-white/10 bg-[#090d16]/80 px-5 py-6 backdrop-blur-xl lg:block">
+        <aside className="hidden min-h-dvh border-r border-[var(--qv-border)] bg-[var(--qv-card)]/80 px-5 py-6 backdrop-blur-xl lg:block">
           <div className="sticky top-6">
             <Link className="flex items-center gap-3" href="/">
-              <span className="grid size-9 place-items-center rounded-xl bg-[#002FA7] text-sm font-bold text-white">
-                QV
-              </span>
+              <QuickVoiceLogo />
               <span>
-                <span className="block text-sm font-semibold">QuickVoice</span>
                 <span className="text-xs text-slate-400">API Reference</span>
               </span>
             </Link>
@@ -182,7 +180,7 @@ export function ApiReference() {
                     <ArrowUpRight aria-hidden="true" className="size-4" />
                   </a>
                 </div>
-                <div className="overflow-hidden rounded-2xl border border-white/10 bg-[#0c111d]">
+                <div className="overflow-hidden rounded-2xl border border-white/10 bg-[var(--qv-card)]">
                   {group.endpoints.map((endpointItem) => (
                     <EndpointRow
                       key={`${endpointItem.method}-${endpointItem.path}`}
@@ -325,7 +323,7 @@ function EndpointRow({ endpoint }: Readonly<{ endpoint: ApiEndpoint }>) {
           ) : null}
           <InfoBlock label="Response" values={[endpoint.response]} />
         </div>
-        <div className="rounded-2xl border border-white/10 bg-[#070a12] p-4">
+        <div className="rounded-2xl border border-white/10 bg-[var(--qv-bg)] p-4">
           <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
             Source
           </p>

--- a/apps/docs/src/components/api/api-reference.tsx
+++ b/apps/docs/src/components/api/api-reference.tsx
@@ -28,7 +28,6 @@ const methodClass: Record<ApiMethod, string> = {
   POST: "border-sky-500/30 bg-sky-500/10 text-sky-300",
   PATCH: "border-amber-500/30 bg-amber-500/10 text-amber-300",
   DELETE: "border-rose-500/30 bg-rose-500/10 text-rose-300",
-  OPTIONS: "border-slate-500/30 bg-slate-500/10 text-slate-300",
 };
 
 export function ApiReference() {

--- a/apps/docs/src/components/api/scalar-api-reference.tsx
+++ b/apps/docs/src/components/api/scalar-api-reference.tsx
@@ -51,7 +51,7 @@ export function ScalarApiReference() {
       theme: theme === "dark" ? "moon" : "default",
       metaData: {
         title: "QuickVoice REST API reference",
-        description: "Interactive QuickVoice OpenAPI reference with request schemas, responses, authentication, and a built-in API client.",
+        description: "QuickVoice endpoint reference. In Ask AI, explain the selected operation first, including its method, path, use case, auth, request fields, response, and side effects.",
       },
     });
 

--- a/apps/docs/src/components/docs-shell.tsx
+++ b/apps/docs/src/components/docs-shell.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { QuickVoiceLogo } from "@/components/quickvoice-logo";
 import { docsNav } from "@/lib/docs-nav";
 
 export function DocsShell({ children }: Readonly<{ children: React.ReactNode }>) {
@@ -7,8 +8,7 @@ export function DocsShell({ children }: Readonly<{ children: React.ReactNode }>)
       <header className="sticky top-0 z-40 border-b border-[var(--qv-border)] bg-white/90 backdrop-blur-xl">
         <div className="mx-auto flex h-14 max-w-[1440px] items-center justify-between px-4 sm:px-6 lg:px-8">
           <Link className="flex items-center gap-3 font-semibold tracking-tight" href="/">
-            <span className="grid size-8 place-items-center rounded-lg bg-[var(--qv-blue)] text-sm font-bold text-white">QV</span>
-            <span>QuickVoice Docs</span>
+            <QuickVoiceLogo label="QuickVoice Docs" compact />
           </Link>
           <nav className="hidden items-center gap-5 text-sm text-[var(--qv-muted)] md:flex">
             <Link className="transition hover:text-[var(--qv-ink)]" href="/api-reference">API Reference</Link>

--- a/apps/docs/src/components/mcp/mcp-footer.tsx
+++ b/apps/docs/src/components/mcp/mcp-footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { QuickVoiceLogo } from "@/components/quickvoice-logo";
 
 const groups = [
   {
@@ -30,8 +31,7 @@ export function McpFooter() {
       <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[1.2fr_1.8fr]">
         <div>
           <Link className="flex items-center gap-3 font-semibold" href="/">
-            <span className="grid size-9 place-items-center rounded-xl bg-[var(--qv-blue)] text-sm font-bold">QV</span>
-            <span>QuickVoice</span>
+            <QuickVoiceLogo />
           </Link>
           <p className="mt-4 max-w-md text-sm leading-6 text-slate-400">QuickVoice helps teams build, operate, and connect AI voice agents for calls, widgets, and support workflows.</p>
         </div>

--- a/apps/docs/src/components/mcp/mcp-page-nav.tsx
+++ b/apps/docs/src/components/mcp/mcp-page-nav.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { QuickVoiceLogo } from "@/components/quickvoice-logo";
 
 const links = [
   { href: "#overview", label: "Overview" },
@@ -14,8 +15,7 @@ export function McpPageNav() {
     <header className="sticky top-0 z-40 border-b border-[var(--qv-border)] bg-white/90 backdrop-blur-xl">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link className="flex items-center gap-3 font-semibold tracking-tight text-slate-950" href="/">
-          <span className="grid size-8 place-items-center rounded-xl bg-[var(--qv-blue)] text-sm font-bold text-white shadow-sm">QV</span>
-          <span>QuickVoice</span>
+          <QuickVoiceLogo compact />
         </Link>
         <nav aria-label="MCP page sections" className="hidden items-center gap-1 rounded-full border border-[var(--qv-border)] bg-white p-1 text-sm shadow-sm md:flex">
           {links.map((link) => (

--- a/apps/docs/src/components/quickvoice-logo.tsx
+++ b/apps/docs/src/components/quickvoice-logo.tsx
@@ -1,0 +1,37 @@
+export function QuickVoiceLogo({
+  label = "QuickVoice",
+  compact = false,
+}: {
+  label?: string;
+  compact?: boolean;
+}) {
+  return (
+    <span className="inline-flex items-center gap-2 text-[var(--qv-ink)]">
+      <span className="grid size-8 shrink-0 place-items-center text-[var(--qv-ink)]">
+        <svg
+          aria-hidden="true"
+          className="size-8"
+          viewBox="0 0 64 64"
+          xmlns="http://www.w3.org/2000/svg"
+          shapeRendering="geometricPrecision"
+        >
+          <g transform="rotate(-12 32 32)">
+            <circle
+              cx="32"
+              cy="32"
+              r="28"
+              stroke="currentColor"
+              strokeWidth="6"
+              fill="none"
+            />
+            <rect x="18" y="26" width="6" height="12" rx="3" fill="currentColor" />
+            <rect x="26" y="20" width="6" height="24" rx="3" fill="currentColor" />
+            <rect x="34" y="20" width="6" height="24" rx="3" fill="currentColor" />
+            <rect x="42" y="26" width="6" height="12" rx="3" fill="currentColor" />
+          </g>
+        </svg>
+      </span>
+      <span className={compact ? "hidden sm:inline" : undefined}>{label}</span>
+    </span>
+  );
+}

--- a/apps/docs/src/data/api-reference.ts
+++ b/apps/docs/src/data/api-reference.ts
@@ -1,4 +1,4 @@
-export type ApiMethod = "GET" | "POST" | "PATCH" | "DELETE" | "OPTIONS";
+export type ApiMethod = "GET" | "POST" | "PATCH" | "DELETE";
 
 export type ApiEndpoint = {
   method: ApiMethod;
@@ -25,7 +25,6 @@ export const apiBaseUrl = "https://api.quickvoice.co/api/v1";
 export const apiAuthNotes = [
   "Most console and product APIs accept either a Better Auth session cookie or an organization-scoped API key.",
   "Send API keys with the x-api-key header.",
-  "Internal runtime routes require the internal API token and are not intended for browser clients.",
   "Public website-widget routes are origin-gated by the widget allowedOrigins configuration.",
 ];
 
@@ -146,30 +145,6 @@ export const apiGroups: ApiGroup[] = [
         undefined,
         "200 { success, message, data: AgentConfiguration }",
       ),
-      endpoint(
-        "GET",
-        "/agents/internal-config/{agentId}",
-        "Runtime-only lookup of agent configuration by ID.",
-        "Internal API key",
-        "internal",
-        "apps/server/src/modules/agent/agent.route.ts",
-        undefined,
-        ["agentId: uuid"],
-        undefined,
-        "200 { success, message, data: RuntimeAgentConfiguration }",
-      ),
-      endpoint(
-        "GET",
-        "/agents/number-config/{phoneNumber}",
-        "Runtime-only lookup of agent configuration by assigned phone number.",
-        "Internal API key",
-        "internal",
-        "apps/server/src/modules/agent/agent.route.ts",
-        undefined,
-        ["phoneNumber: E.164 or stored phone number"],
-        undefined,
-        "200 { success, message, data: RuntimeAgentConfiguration }",
-      ),
     ],
   },
   {
@@ -251,24 +226,6 @@ export const apiGroups: ApiGroup[] = [
     description:
       "Ingest completed calls, inspect historical logs, read transcripts, and control live calls.",
     endpoints: [
-      endpoint(
-        "POST",
-        "/calls",
-        "Internal LiveKit runner call-log ingest endpoint.",
-        "Internal API key",
-        "internal",
-        "apps/server/src/modules/calllogs/calllog.route.ts",
-        undefined,
-        undefined,
-        [
-          "organizationId, agentId, callId",
-          "startTime, endTime, direction, durationSeconds, status",
-          "recordingSid, transcripts[]",
-          "toNumber?, fromNumber?, provider?",
-          "metadata?, extractedData?, evaluatedData?",
-        ],
-        "201 { success, message, data: CallLog }",
-      ),
       endpoint(
         "GET",
         "/calls",
@@ -486,18 +443,6 @@ export const apiGroups: ApiGroup[] = [
         ["campaignId: uuid"],
         undefined,
         "200 { success, message, data: BatchCampaign }",
-      ),
-      endpoint(
-        "GET",
-        "/outbound-calls/{outboundId}/status",
-        "Fetch compact outbound call status.",
-        "Session or API key",
-        "outboundCalls:read",
-        "apps/server/src/modules/outbound/outbound-call.route.ts",
-        undefined,
-        ["outboundId: uuid"],
-        undefined,
-        "200 { success, message, data: { outboundId, status, failureReason, updatedAt } }",
       ),
       endpoint(
         "GET",
@@ -942,18 +887,6 @@ export const apiGroups: ApiGroup[] = [
         ["widgetId: uuid"],
         undefined,
         "200 { success, message, data: null }",
-      ),
-      endpoint(
-        "OPTIONS",
-        "/public/widgets/{widgetId}/config",
-        "CORS preflight for public widget configuration.",
-        "Origin allowlist",
-        undefined,
-        "apps/server/src/modules/widgets/widget.route.ts",
-        undefined,
-        ["widgetId: uuid"],
-        undefined,
-        "204 when origin is allowed, 403 otherwise",
       ),
       endpoint(
         "GET",

--- a/apps/docs/src/lib/docs-nav.ts
+++ b/apps/docs/src/lib/docs-nav.ts
@@ -18,9 +18,6 @@ export const docsNav: DocsNavGroup[] = [
       { title: "API reference", href: "/api-reference", description: "REST routes, auth, schemas, and responses." },
       { title: "Guides", href: "/guides", description: "Implementation and operations guides." },
       { title: "Changelog", href: "/changelog", description: "Documentation, API, and MCP updates." },
-      { title: "Quickstart", href: "/mcp/quickstart", description: "Connect an MCP client in minutes." },
-      { title: "Architecture", href: "/mcp/architecture", description: "Recommended app boundaries for docs, MCP, and APIs." },
-      { title: "API keys", href: "/mcp/api-keys", description: "Create least-privilege keys for MCP clients." },
     ],
   },
   {
@@ -36,7 +33,7 @@ export const docsNav: DocsNavGroup[] = [
     items: [
       { title: "Troubleshooting", href: "/mcp/troubleshooting", description: "Fix common connection and session errors." },
       { title: "Self-hosting", href: "/mcp/self-hosting", description: "Deploy the dedicated MCP service on ECS." },
-      { title: "Changelog", href: "/mcp/changelog", description: "Tool and resource schema changes." },
+      { title: "MCP changelog", href: "/mcp/changelog", description: "Tool and resource schema changes." },
     ],
   },
 ];

--- a/apps/docs/src/lib/openapi.ts
+++ b/apps/docs/src/lib/openapi.ts
@@ -30,6 +30,9 @@ type OpenApiOperation = {
   responses: Record<string, { description: string }>;
   "x-quickvoice-source": string;
   "x-quickvoice-permission"?: string;
+  "x-quickvoice-ai-context": string;
+  "x-quickvoice-use-case": string;
+  "x-quickvoice-side-effects": string;
 };
 
 type OpenApiPathItem = Partial<Record<Lowercase<ApiMethod>, OpenApiOperation>>;
@@ -46,15 +49,17 @@ export type QuickVoiceOpenApiDocument = {
   paths: Record<string, OpenApiPathItem>;
   components: {
     securitySchemes: {
-      bearerAuth: {
-        type: "http";
-        scheme: "bearer";
-        bearerFormat: "QuickVoice API key or session token";
+      sessionCookie: {
+        type: "apiKey";
+        in: "cookie";
+        name: "better-auth.session_token";
+        description: string;
       };
-      internalApiKey: {
-        type: "http";
-        scheme: "bearer";
-        bearerFormat: "Internal runtime token";
+      apiKey: {
+        type: "apiKey";
+        in: "header";
+        name: "x-api-key";
+        description: string;
       };
     };
   };
@@ -66,7 +71,7 @@ export function buildQuickVoiceOpenApi(): QuickVoiceOpenApiDocument {
     info: {
       title: "QuickVoice REST API",
       version: "2026-07",
-      description: "Interactive OpenAPI reference for QuickVoice agents, calls, phone numbers, outbound workflows, tools, MCP integrations, website widgets, and operational APIs.",
+      description: "Interactive OpenAPI reference for QuickVoice REST operations. In Ask AI flows, answer questions using the selected operation description first instead of giving a broad overview of the full API catalog.",
     },
     servers: [
       {
@@ -78,15 +83,18 @@ export function buildQuickVoiceOpenApi(): QuickVoiceOpenApiDocument {
     paths: buildPaths(),
     components: {
       securitySchemes: {
-        bearerAuth: {
-          type: "http",
-          scheme: "bearer",
-          bearerFormat: "QuickVoice API key or session token",
+        sessionCookie: {
+          type: "apiKey",
+          in: "cookie",
+          name: "better-auth.session_token",
+          description:
+            "Better Auth session cookie from the console app. Browsers normally send it only when the docs and API share a compatible origin.",
         },
-        internalApiKey: {
-          type: "http",
-          scheme: "bearer",
-          bearerFormat: "Internal runtime token",
+        apiKey: {
+          type: "apiKey",
+          in: "header",
+          name: "x-api-key",
+          description: "Organization-scoped QuickVoice API key. Send the raw key in the x-api-key header.",
         },
       },
     },
@@ -120,15 +128,126 @@ function buildPathItem(endpoint: ApiEndpoint, tag: string): OpenApiPathItem {
       responses: buildResponses(endpoint),
       "x-quickvoice-source": endpoint.source,
       ...(endpoint.permission ? { "x-quickvoice-permission": endpoint.permission } : {}),
+      "x-quickvoice-ai-context": buildAiContext(endpoint),
+      "x-quickvoice-use-case": buildUseCase(endpoint),
+      "x-quickvoice-side-effects": buildSideEffects(endpoint),
     },
   };
 }
 
 function buildDescription(endpoint: ApiEndpoint) {
-  const parts = [endpoint.summary, `Authentication: ${endpoint.auth}.`];
+  const aiContext = buildAiContext(endpoint);
+  const parts = [
+    `Selected endpoint: ${endpoint.method} ${endpoint.path}.`,
+    `What it does: ${endpoint.summary}`,
+    `When to use it: ${buildUseCase(endpoint)}`,
+    `Side effects and risk: ${buildSideEffects(endpoint)}`,
+    `Authentication: ${endpoint.auth}.`,
+  ];
   if (endpoint.permission) parts.push(`Permission: ${endpoint.permission}.`);
+  if (endpoint.params?.length) parts.push(`Path parameters: ${endpoint.params.join("; ")}.`);
+  if (endpoint.query?.length) parts.push(`Query parameters: ${endpoint.query.join("; ")}.`);
+  if (endpoint.body?.length) parts.push(`Request body: ${endpoint.body.join("; ")}.`);
+  parts.push(`Response: ${endpoint.response}.`);
+  parts.push(
+    `Ask AI guidance: If the user asks "what this API does" while this operation is selected, answer only about ${endpoint.method} ${endpoint.path}. Do not summarize the whole QuickVoice API catalog unless the user explicitly asks for the whole catalog.`,
+  );
+  parts.push(`AI context: ${aiContext}`);
   parts.push(`Source: ${endpoint.source}.`);
   return parts.join("\n\n");
+}
+
+function buildAiContext(endpoint: ApiEndpoint) {
+  return `${endpoint.method} ${endpoint.path} ${endpoint.summary} Use case: ${buildUseCase(endpoint)} Side effects: ${buildSideEffects(endpoint)}`;
+}
+
+function buildUseCase(endpoint: ApiEndpoint) {
+  const key = `${endpoint.method} ${endpoint.path}`;
+  const useCases: Record<string, string> = {
+    "POST /agents": "Use this when an admin or integration needs to create a new voice agent programmatically from a template or blank setup.",
+    "GET /agents": "Use this to populate agent lists, let users select an agent, or sync agent inventory into another system.",
+    "GET /agents/voice/catalog": "Use this before saving voice configuration so the UI or integration can offer only supported model and voice choices.",
+    "POST /agents/{agentId}/preview-session": "Use this to test an agent in the browser before assigning a phone number or launching real calls.",
+    "PATCH /agents/{id}": "Use this for lightweight agent metadata changes such as renaming or activating/deactivating an agent.",
+    "DELETE /agents/{agentId}": "Use this when an agent should be permanently removed from the organization.",
+    "POST /agents/{agentId}/config": "Use this to save the complete behavior and runtime configuration for an agent.",
+    "GET /agents/{agentId}/config": "Use this to load an agent's saved configuration into an editor or audit workflow.",
+    "GET /numbers/search": "Use this when a user needs to discover available phone numbers before purchase.",
+    "GET /numbers": "Use this to show all phone numbers owned by the organization and their agent assignments.",
+    "POST /numbers": "Use this to purchase or provision a selected provider phone number.",
+    "PATCH /numbers/{phId}": "Use this to route a phone number to a different agent or unassign it.",
+    "DELETE /numbers/{phId}": "Use this to release a phone number that is no longer needed.",
+    "GET /calls": "Use this to build call-history views, export call activity, or audit call outcomes with filters.",
+    "GET /calls/live": "Use this to show currently active calls in an operations console.",
+    "POST /calls/live/end": "Use this when an operator needs to force-end a stuck or unwanted live call.",
+    "GET /calls/{callId}": "Use this to inspect one call's metadata, status, recording, and routing information.",
+    "GET /calls/{callId}/transcripts": "Use this to page through transcript messages for one call without loading every call log field.",
+    "DELETE /calls/{callId}": "Use this for privacy, retention, or cleanup workflows that remove a call record.",
+    "GET /dashboard/summary": "Use this to power dashboard KPIs and charts without manually aggregating raw call logs.",
+    "GET /outbound-calls": "Use this to list outbound attempts and campaign calls with operational filters.",
+    "POST /outbound-calls/quick": "Use this to place one immediate outbound call from a chosen agent and caller ID.",
+    "GET /outbound-calls/batch-upload-url": "Use this before creating a campaign so the source CSV/XLSX file can be uploaded directly to storage.",
+    "POST /outbound-calls/batches": "Use this to create a scheduled or immediate outbound campaign from an uploaded source file.",
+    "GET /outbound-calls/batches": "Use this to show campaign history and campaign-level status.",
+    "GET /outbound-calls/batches/{campaignId}": "Use this to inspect one campaign's details and progress.",
+    "POST /outbound-calls/batches/{campaignId}/cancel": "Use this to stop pending work for an outbound batch campaign.",
+    "GET /outbound-calls/{outboundId}": "Use this to inspect full details for one outbound call attempt.",
+    "POST /outbound-calls/{outboundId}/cancel": "Use this to cancel an individual scheduled outbound call before it completes.",
+    "POST /outbound-calls/{outboundId}/retry": "Use this to retry a failed or unanswered outbound call without rebuilding the original request.",
+    "POST /kb": "Use this to register uploaded or URL-based documents as agent knowledge sources.",
+    "GET /kb": "Use this to list knowledge sources and processing status for an organization or agent.",
+    "GET /kb/upload-url": "Use this to securely upload a knowledge file through a presigned storage URL.",
+    "DELETE /kb/{kbId}": "Use this to remove a knowledge source from an agent's retrievable context.",
+    "GET /tools": "Use this to list reusable HTTP tools configured for the organization.",
+    "POST /tools": "Use this to create a callable HTTP tool that agents can use during conversations.",
+    "PATCH /tools/{toolId}": "Use this to update a tool's endpoint, headers, parameters, timeout, or behavior.",
+    "DELETE /tools/{toolId}": "Use this to remove a tool that should no longer be available.",
+    "GET /tools/agent/{agentId}": "Use this to show which tools are currently available to a specific agent.",
+    "POST /tools/{toolId}/attach/{agentId}": "Use this to enable one existing tool for one agent.",
+    "DELETE /tools/{toolId}/detach/{agentId}": "Use this to disable one tool for one agent without deleting the tool globally.",
+    "GET /secrets": "Use this to list stored secret metadata while keeping secret values redacted.",
+    "POST /secrets": "Use this to store a secret value for tools, headers, webhooks, or integrations.",
+    "DELETE /secrets/{secretId}": "Use this to remove a rotated or unused secret.",
+    "GET /mcp/catalog": "Use this to browse MCP servers that can be connected to QuickVoice.",
+    "GET /mcp/connections": "Use this to list remote MCP servers already connected to the organization.",
+    "POST /mcp/connections": "Use this to connect a catalog MCP server or a custom MCP server URL.",
+    "POST /mcp/connections/{mcpConnectionId}/refresh": "Use this to refresh metadata and tool definitions from a connected MCP server.",
+    "DELETE /mcp/connections/{mcpConnectionId}": "Use this to disconnect a remote MCP server from the organization.",
+    "GET /mcp/agent/{agentId}": "Use this to list MCP connections attached to a specific agent.",
+    "POST /mcp/connections/{mcpConnectionId}/attach/{agentId}": "Use this to enable a connected MCP server's tools for an agent.",
+    "DELETE /mcp/connections/{mcpConnectionId}/detach/{agentId}": "Use this to disable a connected MCP server for an agent.",
+    "POST /mcp/connections/{mcpConnectionId}/tools/{toolName}/execute": "Use this for advanced testing or controlled execution of a tool exposed by a connected MCP server.",
+    "GET /agents/{agentId}/widgets": "Use this to list website widgets configured for a specific agent.",
+    "POST /agents/{agentId}/widgets": "Use this to create an embeddable website voice widget for an agent.",
+    "GET /widgets/{widgetId}": "Use this to read one widget's admin configuration.",
+    "PATCH /widgets/{widgetId}": "Use this to update widget theme, origin allowlist, consent text, or enabled state.",
+    "DELETE /widgets/{widgetId}": "Use this to remove a website widget from service.",
+    "GET /public/widgets/{widgetId}/config": "Use this from the embeddable browser widget to load safe public widget configuration.",
+    "POST /public/widgets/{widgetId}/sessions": "Use this from the embeddable browser widget to create a public voice session.",
+    "POST /public/widgets/{widgetId}/sessions/{sessionId}/end": "Use this from the embeddable browser widget to end a public session with its end token.",
+  };
+  return useCases[key] ?? `Use this operation for the ${endpoint.summary.toLowerCase()}`;
+}
+
+function buildSideEffects(endpoint: ApiEndpoint) {
+  if (endpoint.method === "GET") return "Read-only; it should not change QuickVoice data.";
+  if (endpoint.method === "DELETE") return "Destructive; it removes or detaches data and should require user confirmation.";
+  if (endpoint.path.includes("/cancel") || endpoint.path.includes("/end")) {
+    return "Stops active or scheduled work; confirm before use.";
+  }
+  if (endpoint.path.includes("/retry")) {
+    return "Can re-run a call or workflow; confirm before use because it may contact a person or consume resources.";
+  }
+  if (endpoint.path.includes("/execute")) {
+    return "Executes an external tool; review the tool arguments and expected effects before use.";
+  }
+  if (endpoint.path.includes("/numbers") && endpoint.method === "POST") {
+    return "Can provision billable telephony resources; confirm before use.";
+  }
+  if (endpoint.path.includes("/quick") || endpoint.path.includes("/sessions")) {
+    return "Creates a real-time call/session; it can consume minutes or contact a person, so confirm intent before using it.";
+  }
+  return "Writes or updates QuickVoice data; require appropriate authorization and user intent.";
 }
 
 function buildParameters(endpoint: ApiEndpoint): OpenApiParameter[] | undefined {
@@ -151,7 +270,7 @@ function buildRequestBody(endpoint: ApiEndpoint): OpenApiOperation["requestBody"
   if (!endpoint.body?.length) return undefined;
 
   return {
-    required: !["GET", "DELETE", "OPTIONS"].includes(endpoint.method),
+    required: !["GET", "DELETE"].includes(endpoint.method),
     content: {
       "application/json": {
         schema: {
@@ -170,9 +289,8 @@ function buildRequestBody(endpoint: ApiEndpoint): OpenApiOperation["requestBody"
 }
 
 function buildSecurity(endpoint: ApiEndpoint): OpenApiOperation["security"] {
-  if (endpoint.auth.toLowerCase().includes("internal")) return [{ internalApiKey: [] }];
   if (endpoint.auth.toLowerCase().includes("origin")) return undefined;
-  return [{ bearerAuth: [] }];
+  return [{ sessionCookie: [] }, { apiKey: [] }];
 }
 
 function buildResponses(endpoint: ApiEndpoint): OpenApiOperation["responses"] {

--- a/apps/server/.env.dev.example
+++ b/apps/server/.env.dev.example
@@ -4,6 +4,9 @@ PORT=5000
 SERVER_URL=http://localhost:5000
 CONSOLE_URL=http://localhost:3000
 WEB_URL=http://localhost:3001
+DOCS_URL=http://localhost:3002
+# Optional comma-separated extra browser origins allowed to call the API.
+CORS_ORIGINS=
 
 # Dev-only Docker Compose credentials. Do not reuse these outside local setup.
 DATABASE_URL=postgresql://quickvoice:quickvoice@localhost:5432/quickvoice

--- a/apps/server/src/config/origins.ts
+++ b/apps/server/src/config/origins.ts
@@ -16,6 +16,9 @@ export const trustedOrigins = Array.from(
   new Set(
     [
       ...splitOrigins(process.env.CONSOLE_URL),
+      ...splitOrigins(process.env.WEB_URL),
+      ...splitOrigins(process.env.DOCS_URL),
+      ...splitOrigins(process.env.CORS_ORIGINS),
       serverBaseUrl,
     ].map(trimTrailingSlashes),
   ),


### PR DESCRIPTION
## Summary

- Align the docs app styling with the QuickVoice visual theme.
- Improve the API reference/OpenAPI context so Scalar Ask AI answers from the selected endpoint instead of summarizing the whole API catalog.
- Remove redundant public API reference entries and trim duplicate docs sidebar links.
- Add docs origin support in server CORS development configuration.

## Validation

- `pnpm --filter docs check-types`
- `pnpm --filter docs lint`
- `git diff --check`

## Notes

This PR targets `main` from `agent/docs-quickvoice-theme`.