### PR TITLE
Add release metadata check

### DIFF
--- a/docs/releases/release-checklist.md
+++ b/docs/releases/release-checklist.md
@@ -20,6 +20,7 @@ Use Node.js `^20.19 || ^22.13 || >=24`; CI currently uses Node 24. Start from a 
 ```sh
 corepack prepare pnpm@9.0.0 --activate
 pnpm install --frozen-lockfile
+pnpm release:check -- v0.1.0 --draft
 pnpm check:tasks
 pnpm check:configs
 pnpm lint

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "audit:deps": "node scripts/security-audit.mjs",
     "claims:audit": "node scripts/audit-public-claims.mjs",
     "claims:audit:seo": "node scripts/check-seo-campaign.mjs",
-    "claims:audit:launch": "node scripts/audit-public-claims.mjs --target apps/web/src/app/open-source --target apps/web/src/components/open-source"
+    "claims:audit:launch": "node scripts/audit-public-claims.mjs --target apps/web/src/app/open-source --target apps/web/src/components/open-source",
+    "release:check": "node scripts/check-release-metadata.mjs"
   },
   "devDependencies": {
     "prettier": "^3.7.4",

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+import { access, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REQUIRED_SECTIONS = [
+  "Status",
+  "Install For Evaluation",
+  "Known Limitations",
+  "Verification Status",
+];
+
+function parseArgs(argv) {
+  const options = {
+    draft: false,
+    root: fileURLToPath(new URL("../", import.meta.url)),
+    version: undefined,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "--draft") {
+      options.draft = true;
+    } else if (arg === "--root") {
+      index += 1;
+      options.root = argv[index];
+    } else if (arg?.startsWith("--root=")) {
+      options.root = arg.slice("--root=".length);
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg?.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else if (!options.version) {
+      options.version = arg;
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function usage() {
+  return `Usage: node scripts/check-release-metadata.mjs [--root PATH] <version> [--draft]
+
+Checks that release notes, changelog headings, and readiness sections agree before a tag is created.
+
+Examples:
+  pnpm release:check -- v0.1.0 --draft
+  pnpm release:check -- v0.1.0
+`;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+async function exists(path) {
+  try {
+    await access(path, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasHeading(markdown, heading) {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^#{1,6}\\s+${escaped}\\s*$`, "im").test(markdown);
+}
+
+function hasRequiredSection(markdown, section) {
+  if (hasHeading(markdown, section)) {
+    return true;
+  }
+  if (section === "Status") {
+    return /^>\s*\*\*Status:/im.test(markdown);
+  }
+  return false;
+}
+
+async function readRequired(path, label) {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    throw new Error(
+      `${label} is missing or unreadable at ${path}: ${error.message}`,
+    );
+  }
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  if (!options.version) {
+    throw new Error("Candidate version is required.\n\n" + usage());
+  }
+
+  const root = resolve(options.root);
+  const version = options.version;
+  const changelogPath = resolve(root, "CHANGELOG.md");
+  const releaseDir = resolve(root, "docs", "releases");
+  const notesPath = resolve(releaseDir, `${version}.md`);
+  const draftNotesPath = resolve(releaseDir, `${version}-draft.md`);
+
+  if (options.draft) {
+    const draft = await readRequired(draftNotesPath, "Draft release notes");
+    const missing = REQUIRED_SECTIONS.filter(
+      (section) => !hasRequiredSection(draft, section),
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `Draft release notes ${draftNotesPath} missing required section(s): ${missing.join(", ")}`,
+      );
+    }
+    if (!/draft|not released/i.test(draft)) {
+      throw new Error(
+        `Draft release notes ${draftNotesPath} must explicitly say the candidate is draft/not released`,
+      );
+    }
+    if (await exists(notesPath)) {
+      throw new Error(
+        `Draft mode expected ${version}-draft.md only, but found publish notes ${notesPath}`,
+      );
+    }
+    console.log(`${version}: draft release notes found at ${draftNotesPath}`);
+    console.log(
+      `${version}: no published release claimed; draft mode does not create tags or releases`,
+    );
+    return;
+  }
+
+  const changelog = await readRequired(changelogPath, "CHANGELOG.md");
+  if (
+    !hasHeading(changelog, version) &&
+    !new RegExp(
+      `^##\\s+${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+      "im",
+    ).test(changelog)
+  ) {
+    throw new Error(
+      `CHANGELOG.md does not contain a release heading for ${version}`,
+    );
+  }
+
+  const notes = await readRequired(notesPath, "Release notes");
+  if (!hasHeading(notes, `QuickVoice ${version}`)) {
+    throw new Error(
+      `Release notes title in ${notesPath} must be "# QuickVoice ${version}"`,
+    );
+  }
+
+  if (/draft|not released/i.test(notes)) {
+    throw new Error(
+      `${notesPath} still contains draft/not released wording; publish notes must be final`,
+    );
+  }
+
+  const missing = REQUIRED_SECTIONS.filter(
+    (section) => !hasRequiredSection(notes, section),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `${notesPath} missing required section(s): ${missing.join(", ")}`,
+    );
+  }
+
+  console.log(`${version}: CHANGELOG.md heading found`);
+  console.log(`${version}: release notes file found at ${notesPath}`);
+  for (const section of REQUIRED_SECTIONS) {
+    console.log(`${version}: required section present: ${section}`);
+  }
+  console.log(
+    `${version}: release metadata check passed; no tag, release, commit, or remote change created`,
+  );
+}
+
+try {
+  await run();
+} catch (error) {
+  fail(error.message);
+}

--- a/tests/release-metadata.test.mjs
+++ b/tests/release-metadata.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = new URL("../", import.meta.url);
+const releaseScript = new URL(
+  "../scripts/check-release-metadata.mjs",
+  import.meta.url,
+);
+const requiredSections = [
+  "Status",
+  "Install For Evaluation",
+  "Known Limitations",
+  "Verification Status",
+];
+
+async function writeFixture(
+  root,
+  { changelogVersion = "v0.1.0", notesVersion = "v0.1.0" } = {},
+) {
+  await mkdir(join(root, "docs", "releases"), { recursive: true });
+  await writeFile(
+    join(root, "CHANGELOG.md"),
+    `# Changelog\n\n## ${changelogVersion} - 2026-07-31\n\n### Added\n\n- Release metadata.\n`,
+  );
+  await writeFile(
+    join(root, "docs", "releases", `${notesVersion}.md`),
+    `# QuickVoice ${notesVersion}\n\n## Status\n\nReady.\n\n## Install For Evaluation\n\nRun the documented setup.\n\n## Known Limitations\n\n- Provider coverage varies.\n\n## Verification Status\n\n- [x] Checks passed.\n`,
+  );
+}
+
+function runReleaseCheck(args, root) {
+  return spawnSync(
+    process.execPath,
+    [
+      fileURLToPath(releaseScript),
+      "--root",
+      root instanceof URL ? fileURLToPath(root) : root.toString(),
+      ...args,
+    ],
+    {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+    },
+  );
+}
+
+test("draft mode accepts the explicitly unreleased v0.1.0 draft notes", () => {
+  const result = runReleaseCheck(["v0.1.0", "--draft"], repositoryRoot);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /draft release notes found/);
+  assert.match(result.stdout, /no published release claimed/i);
+});
+
+test("publish mode accepts matching changelog, notes file, title, and required sections", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "quickvoice-release-metadata-"));
+
+  try {
+    await writeFixture(fixture);
+
+    const result = runReleaseCheck(["v0.1.0"], fixture);
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    for (const section of requiredSections) {
+      assert.match(result.stdout, new RegExp(section));
+    }
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("publish mode fails when the changelog heading disagrees with the candidate", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "quickvoice-release-metadata-"));
+
+  try {
+    await writeFixture(fixture, { changelogVersion: "v0.2.0" });
+
+    const result = runReleaseCheck(["v0.1.0"], fixture);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /CHANGELOG.md/);
+    assert.match(result.stderr, /v0.1.0/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("publish mode fails when release notes omit required readiness sections", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "quickvoice-release-metadata-"));
+
+  try {
+    await writeFixture(fixture);
+    await writeFile(
+      join(fixture, "docs", "releases", "v0.1.0.md"),
+      "# QuickVoice v0.1.0\n\n## Status\n\nReady.\n",
+    );
+
+    const result = runReleaseCheck(["v0.1.0"], fixture);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Known Limitations/);
+    assert.match(result.stderr, /Verification Status/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("release checklist documents the metadata check command", async () => {
+  const checklist = await readFile(
+    new URL("../docs/releases/release-checklist.md", import.meta.url),
+    "utf8",
+  );
+  const manifest = JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8"),
+  );
+
+  assert.match(checklist, /pnpm release:check -- v0\.1\.0 --draft/);
+  assert.equal(
+    manifest.scripts["release:check"],
+    "node scripts/check-release-metadata.mjs",
+  );
+});


### PR DESCRIPTION
## Summary

- Add `scripts/check-release-metadata.mjs` and the `pnpm release:check` command.
- Validate draft release notes without claiming a release exists.
- Validate publish-mode changelog, release-note filename/title, and required readiness sections against temporary synthetic Markdown fixtures.
- Document the draft metadata check in the release checklist.

## Issue Or Context

- Related issue: Fixes #66
- First-time contributor?: No
- Area changed: local tooling, release docs, tests

## Verification

- [x] I ran the narrowest check that proves this change.
- [ ] I ran `task doctor` when local tooling, env files, Docker services, or setup docs changed.
- [x] I ran `pnpm ci:local` for shared code, CI, dependency, build, or release workflow changes, or documented the narrower check below.
- [x] Dependency changes are intentional, reflected in `pnpm-lock.yaml`, and any audit suppression changes include an expiry date.
- [x] UI screenshots or recordings are attached for product UI changes, or this PR has no product UI surface.
- [x] Environment changes are documented in the relevant `.env.*.example`, workflow variable notes, or README section.
- [x] I added broader checks if this touches shared code, auth, billing, database models, runtime agent behavior, or production UI.
- [x] For docs-only changes, I reviewed links, commands, and provider-credential boundaries.

Command or review evidence:

```sh
# RED before adding the script/package/docs wiring:
node --test tests/release-metadata.test.mjs
# failed because scripts/check-release-metadata.mjs was missing and the release checklist had no command

pnpm install --frozen-lockfile
node --check scripts/check-release-metadata.mjs
node --test tests/release-metadata.test.mjs
pnpm release:check -- v0.1.0 --draft
node --test tests/*.test.mjs
pnpm check:tasks
pnpm exec prettier --check scripts/check-release-metadata.mjs tests/release-metadata.test.mjs docs/releases/release-checklist.md package.json
git diff --check
```

`node --test tests/*.test.mjs` passed 36/36 root Node tests. I used focused root/release checks instead of full `pnpm ci:local` because this PR only adds release metadata tooling/docs and does not change product runtime, Docker images, Python code, or package dependencies. `pnpm install --frozen-lockfile` completed without lockfile changes.

`task doctor` was not run because this does not change env files, Docker services, local service startup, or setup docs.

No dependency, audit suppression, UI, or environment-template changes are included.

## Launch And Positioning Guardrails

- [x] Public copy keeps the open-source Retell alternative story focused on control, self-hosting, privacy review, cost visibility, and extensibility.
- [x] Competitive comparisons explain tradeoffs without attacking competitors.
- [x] This PR does not invent screenshots, metrics, benchmarks, customers, compliance claims, provider partnerships, or production readiness claims.
- [x] Provider requirements are explicit when real calls, billing, OAuth, email, storage, or deployment need live credentials or product decisions.

## Screenshots Or Recordings

No product UI surface.

## Maintainer Review Notes

- This is release tooling/docs only. The script is read-only and does not create tags, releases, commits, or remote changes.
