### PR TITLE
Add macOS setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ task up:dev
 
 ### Choose Your Host
 
-| Host    | Support level                | Guidance                                                                                                                                                                                                                     |
-| ------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Linux   | Supported                    | Install the prerequisites above, run `task doctor`, then run `task up:dev`.                                                                                                                                                  |
-| macOS   | Supported with current tools | Install Docker Desktop and a modern Bash (`>=4`). The Bash 3.2 bundled with macOS is not sufficient for every orchestration script. Verify `bash --version`, `docker compose version`, and `task --version` before starting. |
-| Windows | Use WSL2                     | Native PowerShell and Command Prompt are not supported by the Bash-based Taskfile scripts. Use WSL2 with Docker Desktop's WSL integration.                                                                                   |
+| Host    | Support level                | Guidance                                                                                                                                                                                                                                                                              |
+| ------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Linux   | Supported                    | Install the prerequisites above, run `task doctor`, then run `task up:dev`.                                                                                                                                                                                                           |
+| macOS   | Supported with current tools | Install Docker Desktop and a modern Bash (`>=4`). The Bash 3.2 bundled with macOS is not sufficient for every orchestration script. Follow the [macOS setup guide](./docs/setup/macos.md) to verify `bash --version`, `docker compose version`, and `task --version` before starting. |
+| Windows | Use WSL2                     | Native PowerShell and Command Prompt are not supported by the Bash-based Taskfile scripts. Use WSL2 with Docker Desktop's WSL integration.                                                                                                                                            |
 
 On Debian, Ubuntu, or WSL2, Docker, Python, and the Go toolchain can be installed with:
 

--- a/docs/setup/macos.md
+++ b/docs/setup/macos.md
@@ -1,0 +1,145 @@
+# macOS Setup
+
+QuickVoice can run on macOS when the shell resolves to a modern Bash and the usual local-development tools are installed. macOS still ships `/bin/bash` 3.2, so verify the Bash that QuickVoice scripts will actually execute before running `task up:dev`.
+
+The orchestration scripts use this shebang:
+
+```sh
+#!/usr/bin/env bash
+```
+
+That means macOS asks `env` to find `bash` on your `PATH`. It does **not** force `/bin/bash`. Do not replace `/bin/bash`, disable system integrity protections, or edit protected system files. Install a newer Bash and put that install location earlier on `PATH`.
+
+## Tested Host Record
+
+Before approving a macOS release or setup PR, record the exact host used for verification in the PR body:
+
+- macOS version:
+- CPU: Apple Silicon or Intel:
+- Bash path and version:
+- Docker Desktop version:
+- Node.js version:
+- Python version:
+- Go Task version:
+
+## Prerequisites
+
+Install these with your preferred package manager or vendor installer:
+
+- Bash `>=4`
+- Node.js `^20.19 || ^22.13 || >=24`
+- Corepack
+- Python 3; Python 3.12 matches CI and the AI runtime image
+- Docker Desktop with Docker Compose v2
+- [Go Task](https://taskfile.dev/)
+
+Homebrew installs command-line tools under different prefixes by CPU family:
+
+- Apple Silicon default: `/opt/homebrew/bin`
+- Intel default: `/usr/local/bin`
+
+If you use Homebrew, make sure the matching prefix appears before `/bin` and `/usr/bin` on `PATH` in the shell that will run QuickVoice.
+
+## Verify The Bash That Scripts Will Use
+
+Run:
+
+```sh
+command -v bash
+type -a bash
+bash --version
+```
+
+Expected result:
+
+- `command -v bash` points to a modern Bash such as `/opt/homebrew/bin/bash` or `/usr/local/bin/bash`.
+- `type -a bash` lists the modern Bash before `/bin/bash`.
+- `bash --version` reports version 4 or newer.
+
+If `/bin/bash` appears first, update your shell startup file so the modern install prefix is earlier on `PATH`, then open a new terminal and rerun the checks. For example, adapt one of these to your shell and install location:
+
+```sh
+export PATH="/opt/homebrew/bin:$PATH"
+export PATH="/usr/local/bin:$PATH"
+```
+
+## Verify The Other Tools
+
+Run these checks from the repository root or from the terminal you will use for QuickVoice:
+
+```sh
+node --version
+corepack --version
+python3 --version
+docker --version
+docker compose version
+task --version
+```
+
+Then run the local preflight:
+
+```sh
+task doctor
+```
+
+`task doctor` should confirm templates, required ports, Docker Compose availability, and local service prerequisites before you start the full development stack.
+
+## Start The Local Stack
+
+After the prerequisite checks pass, run:
+
+```sh
+task up:dev
+```
+
+The development task creates ignored local env files from tracked templates, activates the pinned pnpm version, installs dependencies with the frozen lockfile, starts Postgres and Redis through Docker Compose, runs Prisma migrations, and launches the local services.
+
+## Boundaries
+
+The default local templates are for development only. They are enough for startup and health checks, but real calls, billing, OAuth, email delivery, storage, retrieval, and production deployments still require separately configured provider accounts and secrets.
+
+Do not paste real credentials, phone numbers, recordings, transcripts, provider payloads, or customer data into setup issues or pull requests. Use synthetic local data for troubleshooting.
+
+## Troubleshooting
+
+### `task doctor` reports Bash 3.2
+
+Check which Bash is first on `PATH`:
+
+```sh
+command -v bash
+type -a bash
+bash --version
+```
+
+Install Bash `>=4` if needed and put its directory before `/bin` in `PATH`. Open a new terminal after changing `PATH`.
+
+### Docker Compose is missing
+
+Install or start Docker Desktop, then verify:
+
+```sh
+docker compose version
+```
+
+QuickVoice expects the Compose v2 plugin (`docker compose`), not the legacy standalone `docker-compose` binary.
+
+### Node or Corepack is too old
+
+Install a supported Node.js version with a version manager or vendor package, then enable the repo-pinned pnpm through Corepack when instructed by the setup flow.
+
+```sh
+node --version
+corepack --version
+```
+
+### Apple Silicon vs Intel path mismatch
+
+If you moved machines, restored a shell profile, or installed tools under a different prefix, verify both common Homebrew locations:
+
+```sh
+ls -ld /opt/homebrew/bin /usr/local/bin 2>/dev/null || true
+type -a bash node python3 task
+```
+
+Keep the prefix that actually contains your installed tools earlier on `PATH`.

--- a/tests/macos-setup-doc.test.mjs
+++ b/tests/macos-setup-doc.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+async function text(path) {
+  return readFile(new URL(`../${path}`, import.meta.url), "utf8");
+}
+
+test("README links the tested macOS setup guide", async () => {
+  const readme = await text("README.md");
+
+  assert.match(readme, /\[macOS setup guide\]\(\.\/docs\/setup\/macos\.md\)/i);
+});
+
+test("macOS setup guide explains prerequisite checks without protected system changes", async () => {
+  const guide = await text("docs/setup/macos.md");
+
+  for (const required of [
+    "command -v bash",
+    "bash --version",
+    "type -a bash",
+    "docker compose version",
+    "node --version",
+    "corepack --version",
+    "python3 --version",
+    "task --version",
+    "task doctor",
+    "#!/usr/bin/env bash",
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+  ]) {
+    assert.match(
+      guide,
+      new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+  }
+
+  assert.doesNotMatch(guide, /replace\s+\/bin\/bash/i);
+  assert.doesNotMatch(
+    guide,
+    /sudo\s+(?:nano|vim|vi|edit|mv|rm|cp).*\/bin\/bash/i,
+  );
+  assert.doesNotMatch(guide, /production\s+credential/i);
+  assert.doesNotMatch(guide, /paid\s+provider/i);
+});


### PR DESCRIPTION
## Summary

- Add `docs/setup/macos.md` with tested prerequisite checks for modern Bash, Node/Corepack, Python, Docker Compose, and Go Task.
- Explain how `#!/usr/bin/env bash` resolves Bash from `PATH`, including Apple Silicon and Intel Homebrew prefixes.
- Link the macOS setup guide from the root README.
- Add a focused Node test that guards the README link and the required safety/prerequisite content.

## Issue Or Context

- Related issue: Fixes #56
- First-time contributor?: No
- Area changed: README, docs, local tooling guidance

## Verification

- [x] I ran the narrowest check that proves this change.
- [x] I ran `task doctor` when local tooling, env files, Docker services, or setup docs changed.
- [ ] I ran `pnpm ci:local` for shared code, CI, dependency, build, or release workflow changes, or documented the narrower check below.
- [x] Dependency changes are intentional, reflected in `pnpm-lock.yaml`, and any audit suppression changes include an expiry date.
- [x] UI screenshots or recordings are attached for product UI changes, or this PR has no product UI surface.
- [x] Environment changes are documented in the relevant `.env.*.example`, workflow variable notes, or README section.
- [x] I added broader checks if this touches shared code, auth, billing, database models, runtime agent behavior, or production UI.
- [x] For docs-only changes, I reviewed links, commands, and provider-credential boundaries.

Command or review evidence:

```sh
# RED before adding the guide/link:
node --test tests/macos-setup-doc.test.mjs
# failed because README did not link ./docs/setup/macos.md and docs/setup/macos.md did not exist

node --test tests/macos-setup-doc.test.mjs
node --test tests/*.test.mjs
pnpm exec prettier --check README.md docs/setup/macos.md tests/macos-setup-doc.test.mjs
git diff --check
task doctor
```

Results:

- `tests/macos-setup-doc.test.mjs`: 2/2 passed.
- Root Node tests: 33/33 passed.
- Prettier check passed.
- `git diff --check` passed.
- `task doctor` exited 0. It reported Bash/Task/Go/Node/Corepack/Python/Docker checks OK and warned only that local Postgres/Redis were not running, which is expected before `task docker:up`.

`pnpm ci:local` was not run because this is a docs/setup-guide PR with a focused documentation regression test and no runtime, dependency, build, Docker image, Python, auth, billing, or database changes.

No dependency, audit suppression, product UI, or env-template changes are included.

## Launch And Positioning Guardrails

- [x] Public copy keeps the open-source Retell alternative story focused on control, self-hosting, privacy review, cost visibility, and extensibility.
- [x] Competitive comparisons explain tradeoffs without attacking competitors.
- [x] This PR does not invent screenshots, metrics, benchmarks, customers, compliance claims, provider partnerships, or production readiness claims.
- [x] Provider requirements are explicit when real calls, billing, OAuth, email, storage, or deployment need live credentials or product decisions.

## Screenshots Or Recordings

No product UI surface.

## Maintainer Review Notes

- I verified the commands on Linux in this PR environment. Per #56, a maintainer still needs to record the exact macOS version/CPU used for final macOS verification before treating the guide as tested on macOS.
