### PR TITLE
Complete outbound campaigns after final call

### DIFF
--- a/apps/server/src/modules/calllogs/calllog.repository.ts
+++ b/apps/server/src/modules/calllogs/calllog.repository.ts
@@ -1,4 +1,8 @@
-import { Prisma } from "../../../prisma/generated/prisma/client.js";
+import {
+  CallStatus,
+  CampaignStatus,
+  Prisma,
+} from "../../../prisma/generated/prisma/client.js";
 import { BadRequestError } from "../../common/errors/badRequest.js";
 import prisma from "../../config/prisma.js";
 import { redactJson, redactText } from "../../lib/redaction.js";
@@ -90,11 +94,56 @@ export const saveCallLogInTransaction = async (
         callId: callLog.callId,
         organizationId: input.organizationId,
       });
+    } else {
+      await completeCampaignIfAllOutboundCallsTerminal(
+        tx,
+        input.organizationId,
+        outboundId,
+      );
     }
   }
 
   return callLog;
 };
+
+async function completeCampaignIfAllOutboundCallsTerminal(
+  tx: Prisma.TransactionClient,
+  organizationId: string,
+  outboundId: string,
+) {
+  const outbound = await tx.outboundCall.findFirst({
+    where: { outboundId, organizationId },
+    select: { campaignId: true },
+  });
+  if (!outbound?.campaignId) return;
+
+  const pendingCalls = await tx.outboundCall.count({
+    where: {
+      organizationId,
+      campaignId: outbound.campaignId,
+      status: { in: [CallStatus.SCHEDULED, CallStatus.IN_PROGRESS] },
+    },
+  });
+  if (pendingCalls > 0) return;
+
+  await tx.campaign.updateMany({
+    where: {
+      organizationId,
+      campaignId: outbound.campaignId,
+      status: {
+        in: [
+          CampaignStatus.SCHEDULED,
+          CampaignStatus.ACTIVE,
+          CampaignStatus.PROCESSED,
+        ],
+      },
+    },
+    data: {
+      status: CampaignStatus.COMPLETED,
+      completedAt: new Date(),
+    },
+  });
+}
 
 export function buildCallLogIdentityFields(
   input: IngestCallLogArgs,

--- a/apps/server/tests/calllogs/calllog.repository.test.ts
+++ b/apps/server/tests/calllogs/calllog.repository.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import {
   CallStatus,
+  CampaignStatus,
   TelephonyProvider,
 } from "../../prisma/generated/prisma/client.js";
 import {
@@ -185,4 +186,122 @@ test("duplicate call identifiers cannot cross organization boundaries", async ()
     saveCallLogInTransaction(tx as never, baseInput, true),
     /Call identifier is already in use/,
   );
+});
+
+test("call log ingestion completes the parent campaign after the final outbound call is terminal", async () => {
+  let campaignUpdate: any = null;
+  const tx = {
+    callLog: {
+      createMany: async () => ({ count: 1 }),
+      findUnique: async () => ({
+        callId: baseInput.callId,
+        organizationId: baseInput.organizationId,
+      }),
+    },
+    outboundCall: {
+      updateMany: async () => ({ count: 1 }),
+      findFirst: async () => ({ campaignId: "campaign_123" }),
+      count: async () => 0,
+    },
+    campaign: {
+      updateMany: async (args: any) => {
+        campaignUpdate = args;
+        return { count: 1 };
+      },
+    },
+  };
+
+  await saveCallLogInTransaction(
+    tx as never,
+    {
+      ...baseInput,
+      metadata: { ...baseInput.metadata, outboundId: "outbound_123" },
+    },
+    true,
+  );
+
+  assert.equal(campaignUpdate.where.organizationId, baseInput.organizationId);
+  assert.equal(campaignUpdate.where.campaignId, "campaign_123");
+  assert.deepEqual(campaignUpdate.where.status.in, [
+    CampaignStatus.SCHEDULED,
+    CampaignStatus.ACTIVE,
+    CampaignStatus.PROCESSED,
+  ]);
+  assert.equal(campaignUpdate.data.status, CampaignStatus.COMPLETED);
+  assert.ok(campaignUpdate.data.completedAt instanceof Date);
+});
+
+test("call log ingestion leaves a parent campaign active while sibling outbound calls are pending", async () => {
+  let campaignUpdates = 0;
+  const tx = {
+    callLog: {
+      createMany: async () => ({ count: 1 }),
+      findUnique: async () => ({
+        callId: baseInput.callId,
+        organizationId: baseInput.organizationId,
+      }),
+    },
+    outboundCall: {
+      updateMany: async () => ({ count: 1 }),
+      findFirst: async () => ({ campaignId: "campaign_123" }),
+      count: async () => 1,
+    },
+    campaign: {
+      updateMany: async () => {
+        campaignUpdates += 1;
+        return { count: 0 };
+      },
+    },
+  };
+
+  await saveCallLogInTransaction(
+    tx as never,
+    {
+      ...baseInput,
+      metadata: { ...baseInput.metadata, outboundId: "outbound_123" },
+    },
+    true,
+  );
+
+  assert.equal(campaignUpdates, 0);
+});
+
+test("call log ingestion does not inspect campaign completion for non-campaign outbound calls", async () => {
+  let pendingChecks = 0;
+  let campaignUpdates = 0;
+  const tx = {
+    callLog: {
+      createMany: async () => ({ count: 1 }),
+      findUnique: async () => ({
+        callId: baseInput.callId,
+        organizationId: baseInput.organizationId,
+      }),
+    },
+    outboundCall: {
+      updateMany: async () => ({ count: 1 }),
+      findFirst: async () => ({ campaignId: null }),
+      count: async () => {
+        pendingChecks += 1;
+        return 0;
+      },
+    },
+    campaign: {
+      updateMany: async () => {
+        campaignUpdates += 1;
+        return { count: 0 };
+      },
+    },
+  };
+
+  await saveCallLogInTransaction(
+    tx as never,
+    {
+      ...baseInput,
+      metadata: { ...baseInput.metadata, outboundId: "outbound_123" },
+    },
+    true,
+  );
+
+  assert.equal(pendingChecks, 0);
+  assert.equal(campaignUpdates, 0);
 });


### PR DESCRIPTION
## What changed
- Mark an outbound batch campaign as `COMPLETED` when call-log ingestion links the final non-pending outbound call for that campaign.
- Keep duplicate call-log ingestion idempotent and skip campaign checks for non-campaign outbound calls.
- Add focused call-log repository coverage for final-call completion, pending sibling calls, and non-campaign calls.

## Validation
- `pnpm --filter server exec tsx --test tests/calllogs/calllog.repository.test.ts tests/outbound/outbound-batch.service.test.ts`
- `pnpm --filter server check-types`
- `pnpm --filter server lint`
- `pnpm --filter server test`
- `pnpm audit:deps --audit-level low`