### PR TITLE
fix: include curl in server image health checks

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -37,7 +37,7 @@ ENV NODE_ENV=production
 
 RUN apt-get update -y \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends openssl \
+    && apt-get install -y --no-install-recommends curl openssl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --system --gid 1001 nodejs \


### PR DESCRIPTION
## Summary\n- Adds curl to the QuickVoice server runtime image so Coolify Docker-image HTTP health checks can run against /api/v1/health.\n\n## Verification\n- corepack pnpm --filter server build\n- docker build was attempted locally but Docker daemon is unavailable in this Hermes session.