### PR TITLE
ci: deploy docs to shared S3 prefix

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,7 @@
 # Required repository or production-docs environment variables:
 #   AWS_ROLE_ARN                     GitHub OIDC deployment role
-#   DOCS_S3_BUCKET                   Dedicated S3 bucket name (without s3://)
+#   DOCS_S3_BUCKET                   S3 bucket name (without s3://)
+#   DOCS_S3_PREFIX                   S3 key prefix for docs artifacts (no leading/trailing slash)
 #   CLOUDFRONT_DISTRIBUTION_ID       CloudFront distribution ID
 # Optional: AWS_REGION (defaults to us-east-1), NEXT_PUBLIC_GA_MEASUREMENT_ID
 # The AWS role, S3 bucket, and CloudFront distribution must already exist.
@@ -44,6 +45,7 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
       DOCS_S3_BUCKET: ${{ vars.DOCS_S3_BUCKET }}
+      DOCS_S3_PREFIX: ${{ vars.DOCS_S3_PREFIX || 'quickvoice/docs/prod' }}
       CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
       NEXT_PUBLIC_GA_MEASUREMENT_ID: ${{ vars.NEXT_PUBLIC_GA_MEASUREMENT_ID }}
 
@@ -100,14 +102,14 @@ jobs:
 
           aws s3 sync \
             apps/docs/out/_next/static/ \
-            "s3://${DOCS_S3_BUCKET}/_next/static/" \
+            "s3://${DOCS_S3_BUCKET}/${DOCS_S3_PREFIX}/_next/static/" \
             --delete \
             --cache-control "public,max-age=31536000,immutable" \
             --only-show-errors
 
           aws s3 sync \
             apps/docs/out/ \
-            "s3://${DOCS_S3_BUCKET}/" \
+            "s3://${DOCS_S3_BUCKET}/${DOCS_S3_PREFIX}/" \
             --delete \
             --exclude "_next/static/*" \
             --exclude "index.html" \
@@ -116,7 +118,7 @@ jobs:
 
           aws s3 cp \
             apps/docs/out/index.html \
-            "s3://${DOCS_S3_BUCKET}/index.html" \
+            "s3://${DOCS_S3_BUCKET}/${DOCS_S3_PREFIX}/index.html" \
             --cache-control "no-cache,no-store,must-revalidate" \
             --content-type "text/html; charset=utf-8" \
             --only-show-errors
@@ -145,7 +147,7 @@ jobs:
           {
             echo "## QuickVoice docs deployed"
             echo "- Commit: ${{ github.event.workflow_run.head_sha || github.sha }}"
-            echo "- S3 bucket: ${DOCS_S3_BUCKET}"
+            echo "- S3 location: s3://${DOCS_S3_BUCKET}/${DOCS_S3_PREFIX}/"
             echo "- CloudFront distribution: ${CLOUDFRONT_DISTRIBUTION_ID}"
             echo "- Invalidation: ${{ steps.invalidate.outputs.invalidation_id }}"
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary
- Adds DOCS_S3_PREFIX to the docs deployment workflow
- Uploads QuickVoice docs under s3://quickintell-rcm/quickvoice/docs/prod/
- Keeps CloudFront invalidation driven by CLOUDFRONT_DISTRIBUTION_ID

## Verification
- Checked workflow contains DOCS_S3_PREFIX and prefixed S3 paths
- Live docs verified at https://docs.quickvoice.co/
- OpenAPI verified at https://docs.quickvoice.co/openapi.json
