### PR TITLE
ci: do not wait for docs invalidation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -135,10 +135,6 @@ jobs:
             --query 'Invalidation.Id' \
             --output text)"
 
-          aws cloudfront wait invalidation-completed \
-            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
-            --id "${invalidation_id}"
-
           echo "invalidation_id=${invalidation_id}" >> "${GITHUB_OUTPUT}"
 
       - name: Write deployment summary


### PR DESCRIPTION
## Summary
- Keeps CloudFront invalidation creation for docs deploys
- Removes the waiter call that requires cloudfront:GetInvalidation

## Verification
- Confirmed workflow still creates invalidations
- Confirmed workflow no longer calls aws cloudfront wait invalidation-completed
