### PR TITLE
ci: deploy QuickVoice services through Coolify

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -24,10 +24,9 @@ env:
   SERVER_ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
   AI_ECR_REPOSITORY: ${{ vars.AI_ECR_REPOSITORY }}
   AWS_REGION: ${{ vars.AWS_REGION }}
-  ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
-  ECS_SERVICE: ${{ vars.ECS_SERVICE }}
-  SERVER_ECS_CONTAINER_NAME: ${{ vars.SERVER_ECS_CONTAINER_NAME || 'quickvoice-server' }}
-  AI_ECS_CONTAINER_NAME: ${{ vars.AI_ECS_CONTAINER_NAME || 'quickvoice-ai' }}
+  COOLIFY_API_URL: ${{ vars.COOLIFY_API_URL }}
+  COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID: ${{ vars.COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID }}
+  COOLIFY_QUICKVOICE_AI_RESOURCE_UUID: ${{ vars.COOLIFY_QUICKVOICE_AI_RESOURCE_UUID }}
 
 jobs:
   changes:
@@ -102,8 +101,10 @@ jobs:
           REQUIRED_AWS_REGION: ${{ env.AWS_REGION }}
           REQUIRED_SERVER_ECR_REPOSITORY: ${{ env.SERVER_ECR_REPOSITORY }}
           REQUIRED_AI_ECR_REPOSITORY: ${{ env.AI_ECR_REPOSITORY }}
-          REQUIRED_ECS_CLUSTER: ${{ env.ECS_CLUSTER }}
-          REQUIRED_ECS_SERVICE: ${{ env.ECS_SERVICE }}
+          REQUIRED_COOLIFY_API_URL: ${{ env.COOLIFY_API_URL }}
+          REQUIRED_COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID: ${{ env.COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID }}
+          REQUIRED_COOLIFY_QUICKVOICE_AI_RESOURCE_UUID: ${{ env.COOLIFY_QUICKVOICE_AI_RESOURCE_UUID }}
+          REQUIRED_COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
         run: |
           missing=0
           if [ -z "$REQUIRED_AWS_ROLE_ARN" ]; then
@@ -122,12 +123,20 @@ jobs:
             echo "[fail] Missing GitHub repository variable: AI_ECR_REPOSITORY"
             missing=1
           fi
-          if [ -z "$REQUIRED_ECS_CLUSTER" ]; then
-            echo "[fail] Missing GitHub repository variable: ECS_CLUSTER"
+          if [ -z "$REQUIRED_COOLIFY_API_URL" ]; then
+            echo "[fail] Missing GitHub repository variable: COOLIFY_API_URL"
             missing=1
           fi
-          if [ -z "$REQUIRED_ECS_SERVICE" ]; then
-            echo "[fail] Missing GitHub repository variable: ECS_SERVICE"
+          if [ -z "$REQUIRED_COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID" ]; then
+            echo "[fail] Missing GitHub repository variable: COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID"
+            missing=1
+          fi
+          if [ -z "$REQUIRED_COOLIFY_QUICKVOICE_AI_RESOURCE_UUID" ]; then
+            echo "[fail] Missing GitHub repository variable: COOLIFY_QUICKVOICE_AI_RESOURCE_UUID"
+            missing=1
+          fi
+          if [ -z "$REQUIRED_COOLIFY_API_TOKEN" ]; then
+            echo "[fail] Missing GitHub repository secret: COOLIFY_API_TOKEN"
             missing=1
           fi
 
@@ -141,8 +150,10 @@ jobs:
               echo "- AWS_REGION"
               echo "- ECR_REPOSITORY"
               echo "- AI_ECR_REPOSITORY"
-              echo "- ECS_CLUSTER"
-              echo "- ECS_SERVICE"
+              echo "- COOLIFY_API_URL"
+              echo "- COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID"
+              echo "- COOLIFY_QUICKVOICE_AI_RESOURCE_UUID"
+              echo "- COOLIFY_API_TOKEN secret"
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
@@ -153,10 +164,8 @@ jobs:
             echo "- AWS region: ${REQUIRED_AWS_REGION}"
             echo "- Server ECR repository: ${REQUIRED_SERVER_ECR_REPOSITORY}"
             echo "- AI ECR repository: ${REQUIRED_AI_ECR_REPOSITORY}"
-            echo "- ECS cluster: ${REQUIRED_ECS_CLUSTER}"
-            echo "- ECS service: ${REQUIRED_ECS_SERVICE}"
-            echo "- Server ECS container: ${SERVER_ECS_CONTAINER_NAME}"
-            echo "- AI ECS container: ${AI_ECS_CONTAINER_NAME}"
+            echo "- Coolify server app UUID: ${REQUIRED_COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID}"
+            echo "- Coolify AI app UUID: ${REQUIRED_COOLIFY_QUICKVOICE_AI_RESOURCE_UUID}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   build-server:
@@ -190,13 +199,15 @@ jobs:
         shell: bash
         env:
           IMAGE_TAG: ${{ steps.login-ecr.outputs.registry }}/${{ env.SERVER_ECR_REPOSITORY }}:sha-${{ github.sha }}
+          LATEST_TAG: ${{ steps.login-ecr.outputs.registry }}/${{ env.SERVER_ECR_REPOSITORY }}:latest
         run: |
           set -euo pipefail
           for attempt in 1 2 3; do
             if docker build \
               --file apps/server/Dockerfile \
               --tag "${IMAGE_TAG}" \
-              . && docker push "${IMAGE_TAG}"; then
+              --tag "${LATEST_TAG}" \
+              . && docker push "${IMAGE_TAG}" && docker push "${LATEST_TAG}"; then
               digest="$(aws ecr describe-images \
                 --repository-name "${SERVER_ECR_REPOSITORY}" \
                 --image-ids imageTag="sha-${GITHUB_SHA}" \
@@ -260,13 +271,15 @@ jobs:
         shell: bash
         env:
           IMAGE_TAG: ${{ steps.login-ecr.outputs.registry }}/${{ env.AI_ECR_REPOSITORY }}:sha-${{ github.sha }}
+          LATEST_TAG: ${{ steps.login-ecr.outputs.registry }}/${{ env.AI_ECR_REPOSITORY }}:latest
         run: |
           set -euo pipefail
           for attempt in 1 2 3; do
             if docker build \
               --file apps/ai/Dockerfile \
               --tag "${IMAGE_TAG}" \
-              apps/ai && docker push "${IMAGE_TAG}"; then
+              --tag "${LATEST_TAG}" \
+              apps/ai && docker push "${IMAGE_TAG}" && docker push "${LATEST_TAG}"; then
               digest="$(aws ecr describe-images \
                 --repository-name "${AI_ECR_REPOSITORY}" \
                 --image-ids imageTag="sha-${GITHUB_SHA}" \
@@ -300,7 +313,7 @@ jobs:
         run: docker buildx imagetools inspect "$AI_IMAGE_URI"
 
   deploy:
-    name: Deploy Backend Images to ECS
+    name: Deploy Backend Images to Coolify
     runs-on: self-hosted
     needs: [changes, validate-config, build-server, build-ai]
     if: |
@@ -311,132 +324,60 @@ jobs:
       && (needs.build-ai.result == 'success' || needs.build-ai.result == 'skipped')
     environment:
       name: production-backend
-    permissions:
-      id-token: write
-      contents: read
-    outputs:
-      task_definition: ${{ steps.deploy.outputs.task_definition }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Deploy image(s) to ECS
+      - name: Trigger Coolify deployment(s)
         id: deploy
         env:
           SERVER_CHANGED: ${{ needs.changes.outputs.server }}
           AI_CHANGED: ${{ needs.changes.outputs.ai }}
           SERVER_IMAGE_URI: ${{ needs.build-server.outputs.image_uri }}
+          SERVER_IMAGE_TAG: ${{ needs.build-server.outputs.image_tag }}
           AI_IMAGE_URI: ${{ needs.build-ai.outputs.image_uri }}
+          AI_IMAGE_TAG: ${{ needs.build-ai.outputs.image_tag }}
+          COOLIFY_API_URL: ${{ env.COOLIFY_API_URL }}
+          COOLIFY_SERVER_RESOURCE_UUID: ${{ env.COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID }}
+          COOLIFY_AI_RESOURCE_UUID: ${{ env.COOLIFY_QUICKVOICE_AI_RESOURCE_UUID }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
         run: |
           set -euo pipefail
 
-          current_task_definition_arn="$(aws ecs describe-services \
-            --cluster "$ECS_CLUSTER" \
-            --services "$ECS_SERVICE" \
-            --query 'services[0].taskDefinition' \
-            --output text)"
+          deploy_coolify() {
+            local label="$1"
+            local resource_uuid="$2"
+            local image_uri="$3"
+            local image_tag="$4"
 
-          aws ecs describe-task-definition \
-            --task-definition "$current_task_definition_arn" \
-            --query taskDefinition \
-            > task-definition.json
-
-          check_container() {
-            local container="$1"
-            if ! jq -e --arg container "$container" \
-              '.containerDefinitions[] | select(.name == $container)' task-definition.json > /dev/null; then
-              echo "[fail] Container '${container}' was not found in ${current_task_definition_arn}"
+            if [ -z "$resource_uuid" ]; then
+              echo "[fail] Missing Coolify resource UUID for ${label}."
               exit 1
             fi
+            if [ -z "$image_uri" ]; then
+              echo "[fail] Missing ${label} image digest."
+              exit 1
+            fi
+
+            curl --fail --show-error --silent \
+              --request POST "${COOLIFY_API_URL}/deploy?uuid=${resource_uuid}&force=false" \
+              --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
+              --header "Content-Type: application/json"
+
+            {
+              echo "- ${label} Coolify app UUID: ${resource_uuid}"
+              echo "- ${label} image: ${image_uri}"
+              echo "- ${label} image tag: ${image_tag}"
+            } >> "$GITHUB_STEP_SUMMARY"
           }
 
-          if [ "$SERVER_CHANGED" = "true" ]; then
-            check_container "$SERVER_ECS_CONTAINER_NAME"
-            if [ -z "$SERVER_IMAGE_URI" ]; then
-              echo "[fail] Missing server image digest"
-              exit 1
-            fi
-          fi
-
-          if [ "$AI_CHANGED" = "true" ]; then
-            check_container "$AI_ECS_CONTAINER_NAME"
-            if [ -z "$AI_IMAGE_URI" ]; then
-              echo "[fail] Missing AI image digest"
-              exit 1
-            fi
-          fi
-
-          jq \
-            --arg server_changed "$SERVER_CHANGED" \
-            --arg server_container "$SERVER_ECS_CONTAINER_NAME" \
-            --arg server_image "$SERVER_IMAGE_URI" \
-            --arg ai_changed "$AI_CHANGED" \
-            --arg ai_container "$AI_ECS_CONTAINER_NAME" \
-            --arg ai_image "$AI_IMAGE_URI" '
-            .containerDefinitions |= map(
-              if .name == $server_container then
-                (if $server_changed == "true" then .image = $server_image else . end)
-                | .environment = (((.environment // []) | map(select(.name != "LIVEKIT_AGENT_NAME"))) + [{"name":"LIVEKIT_AGENT_NAME","value":"quickvoice-voice-agent"}])
-                | .secrets = ((.secrets // []) | map(select(.name != "TELNYX_CONNECTION_ID")))
-              elif .name == $ai_container then
-                (if $ai_changed == "true" then .image = $ai_image else . end)
-                | .environment = (((.environment // []) | map(select(
-                    .name != "PINECONE_INDEX"
-                    and .name != "PINECONE_EMBEDDING_MODEL"
-                    and .name != "PINECONE_NAMESPACE"
-                  ))) + [
-                    {"name":"PINECONE_INDEX","value":"quickvoice"},
-                    {"name":"PINECONE_EMBEDDING_MODEL","value":"llama-text-embed-v2"},
-                    {"name":"PINECONE_NAMESPACE","value":"documents"}
-                  ])
-              else . end
-            )
-            | del(
-              .taskDefinitionArn,
-              .revision,
-              .status,
-              .requiresAttributes,
-              .compatibilities,
-              .registeredAt,
-              .registeredBy
-            )
-          ' task-definition.json > new-task-definition.json
-
-          new_task_definition_arn="$(aws ecs register-task-definition \
-            --cli-input-json file://new-task-definition.json \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)"
-
-          aws ecs update-service \
-            --cluster "$ECS_CLUSTER" \
-            --service "$ECS_SERVICE" \
-            --task-definition "$new_task_definition_arn" \
-            --force-new-deployment
-
-          aws ecs wait services-stable \
-            --cluster "$ECS_CLUSTER" \
-            --services "$ECS_SERVICE"
-
-          echo "task_definition=${new_task_definition_arn}" >> "$GITHUB_OUTPUT"
-
           {
-            echo "## ECS deployment"
-            echo "- Cluster: ${ECS_CLUSTER}"
-            echo "- Service: ${ECS_SERVICE}"
-            echo "- Previous task definition: ${current_task_definition_arn}"
-            echo "- New task definition: ${new_task_definition_arn}"
-            if [ "$SERVER_CHANGED" = "true" ]; then
-              echo "- Server container: ${SERVER_ECS_CONTAINER_NAME}"
-              echo "- Server image: ${SERVER_IMAGE_URI}"
-            fi
-            if [ "$AI_CHANGED" = "true" ]; then
-              echo "- AI container: ${AI_ECS_CONTAINER_NAME}"
-              echo "- AI image: ${AI_IMAGE_URI}"
-            fi
+            echo "## Coolify deployment"
           } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$SERVER_CHANGED" = "true" ]; then
+            deploy_coolify "Server" "$COOLIFY_SERVER_RESOURCE_UUID" "$SERVER_IMAGE_URI" "$SERVER_IMAGE_TAG"
+          fi
+          if [ "$AI_CHANGED" = "true" ]; then
+            deploy_coolify "AI" "$COOLIFY_AI_RESOURCE_UUID" "$AI_IMAGE_URI" "$AI_IMAGE_TAG"
+          fi
 
   scan-server:
     name: Scan Server Image
@@ -575,12 +516,10 @@ jobs:
           AI_IMAGE_TAG: ${{ needs.build-ai.outputs.image_tag }}
           SERVER_IMAGE_DIGEST: ${{ needs.build-server.outputs.digest }}
           AI_IMAGE_DIGEST: ${{ needs.build-ai.outputs.digest }}
-          TASK_DEFINITION: ${{ needs.deploy.outputs.task_definition }}
         run: |
           {
             echo "## Rollback metadata"
             echo "- Source commit: ${GITHUB_SHA}"
-            echo "- ECS task definition: ${TASK_DEFINITION}"
             if [ "$SERVER_CHANGED" = "true" ]; then
               echo "- Server image tag: ${SERVER_IMAGE_TAG}"
               echo "- Server image digest: ${SERVER_IMAGE_DIGEST}"

--- a/.github/workflows/deploy-mcp-server.yml
+++ b/.github/workflows/deploy-mcp-server.yml
@@ -24,7 +24,8 @@ permissions:
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
   MCP_ECR_REPOSITORY: ${{ vars.MCP_ECR_REPOSITORY }}
-  MCP_COOLIFY_WEBHOOK_URL: ${{ vars.MCP_COOLIFY_WEBHOOK_URL }}
+  COOLIFY_API_URL: ${{ vars.COOLIFY_API_URL }}
+  COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID: ${{ vars.COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID }}
 
 jobs:
   validate-config:
@@ -36,7 +37,8 @@ jobs:
           REQUIRED_AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
           REQUIRED_AWS_REGION: ${{ env.AWS_REGION }}
           REQUIRED_MCP_ECR_REPOSITORY: ${{ env.MCP_ECR_REPOSITORY }}
-          REQUIRED_MCP_COOLIFY_WEBHOOK_URL: ${{ env.MCP_COOLIFY_WEBHOOK_URL }}
+          REQUIRED_COOLIFY_API_URL: ${{ env.COOLIFY_API_URL }}
+          REQUIRED_COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID: ${{ env.COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID }}
           REQUIRED_COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
         shell: bash
         run: |
@@ -55,8 +57,12 @@ jobs:
             echo "[fail] Missing GitHub repository variable: MCP_ECR_REPOSITORY"
             missing=1
           fi
-          if [ -z "${REQUIRED_MCP_COOLIFY_WEBHOOK_URL}" ]; then
-            echo "[fail] Missing GitHub repository variable: MCP_COOLIFY_WEBHOOK_URL"
+          if [ -z "${REQUIRED_COOLIFY_API_URL}" ]; then
+            echo "[fail] Missing GitHub repository variable: COOLIFY_API_URL"
+            missing=1
+          fi
+          if [ -z "${REQUIRED_COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID}" ]; then
+            echo "[fail] Missing GitHub repository variable: COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID"
             missing=1
           fi
           if [ -z "${REQUIRED_COOLIFY_API_TOKEN}" ]; then
@@ -73,7 +79,8 @@ jobs:
               echo "- Repository variable: AWS_ROLE_ARN"
               echo "- Repository variable: AWS_REGION"
               echo "- Repository variable: MCP_ECR_REPOSITORY"
-              echo "- Repository variable: MCP_COOLIFY_WEBHOOK_URL"
+              echo "- Repository variable: COOLIFY_API_URL"
+              echo "- Repository variable: COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID"
               echo "- Repository secret: COOLIFY_API_TOKEN"
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 1
@@ -84,6 +91,7 @@ jobs:
             echo "[ok] Required GitHub Actions configuration is present."
             echo "- AWS region: ${REQUIRED_AWS_REGION}"
             echo "- MCP ECR repository: ${REQUIRED_MCP_ECR_REPOSITORY}"
+            echo "- Coolify MCP app UUID: ${REQUIRED_COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   security-audit:
@@ -186,9 +194,10 @@ jobs:
     environment:
       name: production-mcp-server
     steps:
-      - name: Call Coolify deploy webhook
+      - name: Trigger Coolify deployment
         env:
-          COOLIFY_WEBHOOK_URL: ${{ env.MCP_COOLIFY_WEBHOOK_URL }}
+          COOLIFY_API_URL: ${{ env.COOLIFY_API_URL }}
+          COOLIFY_RESOURCE_UUID: ${{ env.COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID }}
           COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
           MCP_IMAGE_URI: ${{ needs.build-and-push.outputs.image_uri }}
           MCP_IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
@@ -196,12 +205,13 @@ jobs:
         run: |
           set -euo pipefail
           curl --fail --show-error --silent \
-            --request POST "${COOLIFY_WEBHOOK_URL}" \
+            --request POST "${COOLIFY_API_URL}/deploy?uuid=${COOLIFY_RESOURCE_UUID}&force=false" \
             --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
             --header "Content-Type: application/json"
 
           {
             echo "## Coolify deployment triggered"
+            echo "- Coolify app UUID: ${COOLIFY_RESOURCE_UUID}"
             echo "- Image URI: ${MCP_IMAGE_URI}"
             echo "- Image tag: ${MCP_IMAGE_TAG}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/quickvoice-ai-hotfix-deploy.yml
+++ b/.github/workflows/quickvoice-ai-hotfix-deploy.yml
@@ -4,13 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       ai_image:
-        description: Immutable quickvoice-ai image URI to deploy
+        description: QuickVoice AI image expected to be configured on the Coolify app before triggering deploy
         required: true
         default: 557690613141.dkr.ecr.us-east-1.amazonaws.com/allgpt-co/quickvoice-ai:sha-65e2778ea121f67407906f05595a05b2ab49cdb7@sha256:1be327ebbd515217949cabfcce6e5bd8b010264e72b82c303242623528c111ad
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   deploy-ai:
@@ -19,91 +18,30 @@ jobs:
     environment:
       name: production-backend
     env:
-      AWS_REGION: ${{ vars.AWS_REGION }}
-      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
-      ECS_SERVICE: ${{ vars.ECS_SERVICE }}
-      AI_ECS_CONTAINER_NAME: ${{ vars.AI_ECS_CONTAINER_NAME || 'quickvoice-ai' }}
+      COOLIFY_API_URL: ${{ vars.COOLIFY_API_URL }}
+      COOLIFY_QUICKVOICE_AI_RESOURCE_UUID: ${{ vars.COOLIFY_QUICKVOICE_AI_RESOURCE_UUID }}
       AI_IMAGE: ${{ inputs.ai_image }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Deploy AI image to ECS
+      - name: Trigger Coolify AI deployment
         id: deploy
+        env:
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if [ -z "${AWS_REGION}" ] || [ -z "${ECS_CLUSTER}" ] || [ -z "${ECS_SERVICE}" ]; then
-            echo "[fail] Missing AWS_REGION, ECS_CLUSTER, or ECS_SERVICE repository variable."
+          if [ -z "${COOLIFY_API_URL}" ] || [ -z "${COOLIFY_QUICKVOICE_AI_RESOURCE_UUID}" ] || [ -z "${COOLIFY_API_TOKEN}" ]; then
+            echo "[fail] Missing COOLIFY_API_URL, COOLIFY_QUICKVOICE_AI_RESOURCE_UUID, or COOLIFY_API_TOKEN."
             exit 1
           fi
 
-          current_task_definition_arn="$(aws ecs describe-services \
-            --cluster "${ECS_CLUSTER}" \
-            --services "${ECS_SERVICE}" \
-            --query 'services[0].taskDefinition' \
-            --output text)"
-
-          if [ -z "${current_task_definition_arn}" ] || [ "${current_task_definition_arn}" = "None" ]; then
-            echo "[fail] Could not resolve current task definition for ${ECS_SERVICE}."
-            exit 1
-          fi
-
-          aws ecs describe-task-definition \
-            --task-definition "${current_task_definition_arn}" \
-            --query taskDefinition \
-            > task-definition.json
-
-          if ! jq -e --arg container "${AI_ECS_CONTAINER_NAME}" \
-            '.containerDefinitions[] | select(.name == $container)' task-definition.json > /dev/null; then
-            echo "[fail] Container ${AI_ECS_CONTAINER_NAME} was not found in ${current_task_definition_arn}."
-            exit 1
-          fi
-
-          jq \
-            --arg container "${AI_ECS_CONTAINER_NAME}" \
-            --arg image "${AI_IMAGE}" '
-            .containerDefinitions |= map(
-              if .name == $container then .image = $image else . end
-            )
-            | del(
-              .taskDefinitionArn,
-              .revision,
-              .status,
-              .requiresAttributes,
-              .compatibilities,
-              .registeredAt,
-              .registeredBy
-            )
-          ' task-definition.json > new-task-definition.json
-
-          new_task_definition_arn="$(aws ecs register-task-definition \
-            --cli-input-json file://new-task-definition.json \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)"
-
-          aws ecs update-service \
-            --cluster "${ECS_CLUSTER}" \
-            --service "${ECS_SERVICE}" \
-            --task-definition "${new_task_definition_arn}" \
-            --force-new-deployment
-
-          aws ecs wait services-stable \
-            --cluster "${ECS_CLUSTER}" \
-            --services "${ECS_SERVICE}"
-
-          echo "task_definition=${new_task_definition_arn}" >> "${GITHUB_OUTPUT}"
+          curl --fail --show-error --silent \
+            --request POST "${COOLIFY_API_URL}/deploy?uuid=${COOLIFY_QUICKVOICE_AI_RESOURCE_UUID}&force=false" \
+            --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
+            --header "Content-Type: application/json"
 
           {
             echo "## QuickVoice AI hotfix deploy"
-            echo "- Cluster: ${ECS_CLUSTER}"
-            echo "- Service: ${ECS_SERVICE}"
-            echo "- Container: ${AI_ECS_CONTAINER_NAME}"
-            echo "- Previous task definition: ${current_task_definition_arn}"
-            echo "- New task definition: ${new_task_definition_arn}"
-            echo "- AI image: ${AI_IMAGE}"
+            echo "- Coolify AI app UUID: ${COOLIFY_QUICKVOICE_AI_RESOURCE_UUID}"
+            echo "- Requested AI image: ${AI_IMAGE}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/testing-guides/root-tooling.md
+++ b/testing-guides/root-tooling.md
@@ -58,7 +58,7 @@ Pass if existing local env files are kept, not overwritten. Fail if the script p
 
 Validate local service data flow. `docker-compose.dev.yml` must expose Postgres `postgres:16` on `127.0.0.1:${POSTGRES_PORT:-5432}:5432`, Redis `redis:7` on `127.0.0.1:${REDIS_PORT:-6379}:6379`, and Mailpit `axllent/mailpit:v1.23` only under profile `mail` on `127.0.0.1:1025` and `127.0.0.1:8025`. Pass if both Postgres and Redis have healthchecks and named volumes. Fail if database or Redis ports bind to `0.0.0.0`.
 
-Validate backend deployment flow in `.github/workflows/backend-build.yml`. Pass if deploy waits for `quality-gate`, validates `AWS_ROLE_ARN`, `AWS_REGION`, `ECR_REPOSITORY`, `AI_ECR_REPOSITORY`, `ECS_CLUSTER`, and `ECS_SERVICE`, uses image digests, scans HIGH/CRITICAL vulnerabilities, signs images, updates only configured ECS containers, waits for `services-stable`, and writes rollback metadata. Fail if `:latest` tags, mutable image references, missing scans, or missing rollback metadata appear.
+Validate backend deployment flow in `.github/workflows/backend-build.yml`. Pass if deploy waits for `quality-gate`, validates `AWS_ROLE_ARN`, `AWS_REGION`, `ECR_REPOSITORY`, `AI_ECR_REPOSITORY`, `COOLIFY_API_URL`, `COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID`, `COOLIFY_QUICKVOICE_AI_RESOURCE_UUID`, and `COOLIFY_API_TOKEN`, uses image digests for rollback metadata, scans HIGH/CRITICAL vulnerabilities, signs images, and triggers only configured Coolify app UUIDs. Fail if missing scans, missing rollback metadata, or ECS deployment commands appear.
 
 ## Setup And Required Services
 
@@ -362,9 +362,9 @@ AI flags: set `AI_API_ENABLED=false` and run `scripts/dev-up.sh`. Pass if AI API
 
 Expired audit suppression: run `SECURITY_AUDIT_TODAY=2026-07-20 node scripts/security-audit.mjs --check-suppressions-only`. Pass if it exits non-zero and lists expired suppressions. Fail if expired suppressions are ignored.
 
-Backend deploy missing variables: run the GitHub workflow manually in a repo/environment without required variables. Pass if “Validate deployment configuration” fails and lists missing `AWS_ROLE_ARN`, `AWS_REGION`, `ECR_REPOSITORY`, `AI_ECR_REPOSITORY`, `ECS_CLUSTER`, and `ECS_SERVICE`. Fail if deploy proceeds.
+Backend deploy missing variables: run the GitHub workflow manually in a repo/environment without required variables. Pass if “Validate deployment configuration” fails and lists missing `AWS_ROLE_ARN`, `AWS_REGION`, `ECR_REPOSITORY`, `AI_ECR_REPOSITORY`, `COOLIFY_API_URL`, `COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID`, `COOLIFY_QUICKVOICE_AI_RESOURCE_UUID`, and `COOLIFY_API_TOKEN`. Fail if deploy proceeds.
 
-ECS container mismatch: configure `SERVER_ECS_CONTAINER_NAME` or `AI_ECS_CONTAINER_NAME` to a name absent from the current task definition. Pass if deploy fails before registering a bad task definition. Fail if it silently deploys the wrong container.
+Coolify resource mismatch: configure `COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID` or `COOLIFY_QUICKVOICE_AI_RESOURCE_UUID` to an invalid UUID in a non-production test repository/environment. Pass if the Coolify deploy request fails and the workflow stops. Fail if deploy silently succeeds against the wrong app.
 
 ## Test Data, Fixtures, Accounts, And Roles
 
@@ -400,7 +400,7 @@ Blocked if Docker daemon or Buildx is unavailable. Pass once Compose config rend
 
 Blocked if npm, pip, Docker Hub, PyTorch CPU wheel index, or other package registries are unreachable. Pass when dependency installs complete with frozen lockfile and requirements. Fail if lockfile or requirements are modified to work around network issues without approval.
 
-Blocked for production backend deploy without GitHub repo variables `AWS_ROLE_ARN`, `AWS_REGION`, `ECR_REPOSITORY`, `AI_ECR_REPOSITORY`, `ECS_CLUSTER`, and `ECS_SERVICE`. Pass when the workflow validates variables and deploys through protected `production-backend`. Fail if deploy bypasses the validation step.
+Blocked for production backend deploy without GitHub repo variables `AWS_ROLE_ARN`, `AWS_REGION`, `ECR_REPOSITORY`, `AI_ECR_REPOSITORY`, `COOLIFY_API_URL`, `COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID`, `COOLIFY_QUICKVOICE_AI_RESOURCE_UUID`, and `COOLIFY_API_TOKEN`. Pass when the workflow validates variables and deploys through protected `production-backend`. Fail if deploy bypasses the validation step.
 
 Blocked for LiveKit, Twilio, Telnyx, Stripe, Google OAuth, production email, S3, Smithery, Pinecone, and Gemini-style AI provider checks without credentials and product-owner approval. Pass only with sandbox credentials, documented expected behavior, and no live customer data. Fail if tests use production credentials in local env files.
 

--- a/tests/ecs-deploy-workflows.test.mjs
+++ b/tests/ecs-deploy-workflows.test.mjs
@@ -7,14 +7,16 @@ async function workflow(path) {
   return readFile(new URL(`../.github/workflows/${path}`, import.meta.url), "utf8");
 }
 
-function assertEcsDeploys(workflowBody, expectedContainerName) {
+function assertCoolifyDeploys(workflowBody) {
   assert.match(workflowBody, /group: quickvoice-backend-deploy-\$\{\{ github\.ref \}\}/);
-  assert.match(workflowBody, /ECS_CLUSTER: \$\{\{ vars\.ECS_CLUSTER \}\}/);
-  assert.match(workflowBody, /ECS_SERVICE: \$\{\{ vars\.ECS_SERVICE \}\}/);
-  assert.match(workflowBody, new RegExp(`${expectedContainerName}_ECS_CONTAINER_NAME: \\$\\{\\{ vars\\.${expectedContainerName}_ECS_CONTAINER_NAME \\|\\| '${expectedContainerName === "SERVER" ? "quickvoice-server" : "quickvoice-ai"}' \\}\\}`));
+  assert.match(workflowBody, /COOLIFY_API_URL: \$\{\{ vars\.COOLIFY_API_URL \}\}/);
+  assert.match(workflowBody, /COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID: \$\{\{ vars\.COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID \}\}/);
+  assert.match(workflowBody, /COOLIFY_QUICKVOICE_AI_RESOURCE_UUID: \$\{\{ vars\.COOLIFY_QUICKVOICE_AI_RESOURCE_UUID \}\}/);
 
-  assert.match(workflowBody, /REQUIRED_ECS_CLUSTER: \$\{\{ env\.ECS_CLUSTER \}\}/);
-  assert.match(workflowBody, /REQUIRED_ECS_SERVICE: \$\{\{ env\.ECS_SERVICE \}\}/);
+  assert.match(workflowBody, /REQUIRED_COOLIFY_API_URL: \$\{\{ env\.COOLIFY_API_URL \}\}/);
+  assert.match(workflowBody, /REQUIRED_COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID: \$\{\{ env\.COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID \}\}/);
+  assert.match(workflowBody, /REQUIRED_COOLIFY_QUICKVOICE_AI_RESOURCE_UUID: \$\{\{ env\.COOLIFY_QUICKVOICE_AI_RESOURCE_UUID \}\}/);
+  assert.match(workflowBody, /REQUIRED_COOLIFY_API_TOKEN: \$\{\{ secrets\.COOLIFY_API_TOKEN \}\}/);
 
   assert.match(workflowBody, /image_uri: \$\{\{ steps\.image\.outputs\.image_uri \}\}/);
   assert.match(workflowBody, /SERVER_IMAGE_URI: \$\{\{ needs\.build-server\.outputs\.image_uri \}\}/);
@@ -22,14 +24,14 @@ function assertEcsDeploys(workflowBody, expectedContainerName) {
   assert.match(workflowBody, /SERVER_CHANGED: \$\{\{ needs\.changes\.outputs\.server \}\}/);
   assert.match(workflowBody, /AI_CHANGED: \$\{\{ needs\.changes\.outputs\.ai \}\}/);
   assert.match(workflowBody, /needs: \[changes, validate-config, build-server, build-ai\]/);
-  assert.match(workflowBody, /aws ecs describe-services/);
-  assert.match(workflowBody, /aws ecs register-task-definition/);
-  assert.match(workflowBody, /aws ecs update-service/);
-  assert.match(workflowBody, /--force-new-deployment/);
-  assert.match(workflowBody, /aws ecs wait services-stable/);
+  assert.match(workflowBody, /Trigger Coolify deployment\(s\)/);
+  assert.match(workflowBody, /deploy\?uuid=\$\{resource_uuid\}&force=false/);
+  assert.doesNotMatch(workflowBody, /aws ecs/);
+  assert.doesNotMatch(workflowBody, /ECS_CLUSTER/);
+  assert.doesNotMatch(workflowBody, /ECS_SERVICE/);
 }
 
-test("backend workflow deploys changed images to ECS once", async () => {
+test("backend workflow deploys changed images through Coolify once", async () => {
   const body = await workflow("backend-build.yml");
 
   assert.match(body, /Detect Backend Changes/);
@@ -39,9 +41,30 @@ test("backend workflow deploys changed images to ECS once", async () => {
   assert.match(body, /Build and Push AI Image/);
   assert.match(body, /Smoke test pushed server image manifest/);
   assert.match(body, /Smoke test pushed AI image manifest/);
-  assert.match(body, /Deploy image\(s\) to ECS/);
-  assertEcsDeploys(body, "SERVER");
-  assertEcsDeploys(body, "AI");
+  assertCoolifyDeploys(body);
+});
+
+test("MCP workflow deploys through Coolify API resource UUID", async () => {
+  const body = await workflow("deploy-mcp-server.yml");
+
+  assert.match(body, /COOLIFY_API_URL: \$\{\{ vars\.COOLIFY_API_URL \}\}/);
+  assert.match(body, /COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID: \$\{\{ vars\.COOLIFY_QUICKVOICE_MCP_RESOURCE_UUID \}\}/);
+  assert.match(body, /REQUIRED_COOLIFY_API_TOKEN: \$\{\{ secrets\.COOLIFY_API_TOKEN \}\}/);
+  assert.match(body, /Trigger Coolify deployment/);
+  assert.match(body, /deploy\?uuid=\$\{COOLIFY_RESOURCE_UUID\}&force=false/);
+  assert.doesNotMatch(body, /MCP_COOLIFY_WEBHOOK_URL/);
+});
+
+test("AI hotfix workflow triggers Coolify instead of ECS", async () => {
+  const body = await workflow("quickvoice-ai-hotfix-deploy.yml");
+
+  assert.match(body, /COOLIFY_API_URL: \$\{\{ vars\.COOLIFY_API_URL \}\}/);
+  assert.match(body, /COOLIFY_QUICKVOICE_AI_RESOURCE_UUID: \$\{\{ vars\.COOLIFY_QUICKVOICE_AI_RESOURCE_UUID \}\}/);
+  assert.match(body, /Trigger Coolify AI deployment/);
+  assert.match(body, /deploy\?uuid=\$\{COOLIFY_QUICKVOICE_AI_RESOURCE_UUID\}&force=false/);
+  assert.doesNotMatch(body, /aws ecs/);
+  assert.doesNotMatch(body, /ECS_CLUSTER/);
+  assert.doesNotMatch(body, /ECS_SERVICE/);
 });
 
 test("legacy split backend deploy workflows are removed", async () => {

--- a/tests/root-tooling-ci.test.mjs
+++ b/tests/root-tooling-ci.test.mjs
@@ -190,7 +190,13 @@ test("deploy workflows are gated, immutable, scanned, signed, and environment pr
   assert.match(workflow, /GITHUB_STEP_SUMMARY/);
   assert.match(workflow, /GitHub repository variables/);
   assert.match(workflow, /github\.sha/);
-  assert.doesNotMatch(workflow, /:latest/);
+  assert.match(workflow, /COOLIFY_API_URL/);
+  assert.match(workflow, /COOLIFY_QUICKVOICE_SERVER_RESOURCE_UUID/);
+  assert.match(workflow, /COOLIFY_QUICKVOICE_AI_RESOURCE_UUID/);
+  assert.match(workflow, /deploy\?uuid=\$\{resource_uuid\}&force=false/);
+  assert.doesNotMatch(workflow, /aws ecs/);
+  assert.doesNotMatch(workflow, /ECS_CLUSTER/);
+  assert.doesNotMatch(workflow, /ECS_SERVICE/);
   assert.match(workflow, /docker build \\/);
   assert.match(workflow, /docker push/);
   assert.match(workflow, /aws ecr describe-images/);


### PR DESCRIPTION
## Summary
- Route server and AI deployments through Coolify API instead of ECS.
- Route MCP deployment through shared Coolify API URL plus app UUID.
- Remove stale ECS/webhook repository variables from workflow requirements.
- Update workflow regression tests and deployment guide expectations.

## Verification
- node --test tests/ecs-deploy-workflows.test.mjs
- node --test --test-name-pattern 'deploy workflows are gated|backend workflow deploys|MCP workflow deploys|AI hotfix workflow' tests/root-tooling-ci.test.mjs
- git diff --check

## Deployment validation plan
After merge to main, monitor CI plus backend/MCP/docs deploy workflows and verify public endpoints for API, AI, MCP, web, console, and docs.