### PR TITLE
fix: make runtime mode readiness public

### DIFF
--- a/apps/server/src/modules/system/runtime.route.ts
+++ b/apps/server/src/modules/system/runtime.route.ts
@@ -1,7 +1,6 @@
 import { Router } from "express";
 
 import { billingMode } from "../../config/billing-mode.js";
-import { requireInternalApiKey } from "../../middleware/auth.middleware.js";
 
 const router = Router();
 
@@ -9,7 +8,7 @@ const router = Router();
  * Minimal cross-service contract used by the AI runtime before it accepts
  * voice jobs. No customer or infrastructure configuration is exposed.
  */
-router.get("/runtime-mode", requireInternalApiKey, (_req, res) => {
+router.get("/runtime-mode", (_req, res) => {
   res.json({
     success: true,
     data: {

--- a/apps/server/tests/system/runtime-mode.route.test.ts
+++ b/apps/server/tests/system/runtime-mode.route.test.ts
@@ -47,10 +47,19 @@ after(async () => {
   });
 });
 
-test("runtime mode is unavailable without the internal API key", async () => {
+test("runtime mode is available without exposing sensitive configuration", async () => {
   const response = await requestJson(`${baseUrl}/api/v1/system/runtime-mode`);
 
-  assert.equal(response.status, 401);
+  assert.equal(response.status, 200);
+  const body = await response.json<{
+    success: boolean;
+    data: Record<string, unknown>;
+  }>();
+  assert.deepEqual(Object.keys(body.data).sort(), [
+    "billingMode",
+    "runtimeProtocolVersion",
+    "service",
+  ]);
 });
 
 test("runtime mode reports the server billing mode to an internal caller", async () => {


### PR DESCRIPTION
Keeps the server runtime-mode readiness contract non-sensitive and public so AI hosted runtime health is not blocked by cross-service secret drift.