### PR TITLE
fix: update Coolify image tags before deploy

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -346,6 +346,8 @@ jobs:
             local resource_uuid="$2"
             local image_uri="$3"
             local image_tag="$4"
+            local image_name="${image_tag%:*}"
+            local tag="${image_tag##*:}"
 
             if [ -z "$resource_uuid" ]; then
               echo "[fail] Missing Coolify resource UUID for ${label}."
@@ -357,6 +359,12 @@ jobs:
             fi
 
             curl --fail --show-error --silent \
+              --request PATCH "${COOLIFY_API_URL}/applications/${resource_uuid}" \
+              --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
+              --header "Content-Type: application/json" \
+              --data "$(printf '{"docker_registry_image_name":"%s","docker_registry_image_tag":"%s"}' "$image_name" "$tag")"
+
+            curl --fail --show-error --silent \
               --request POST "${COOLIFY_API_URL}/deploy?uuid=${resource_uuid}&force=false" \
               --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
               --header "Content-Type: application/json"
@@ -365,6 +373,7 @@ jobs:
               echo "- ${label} Coolify app UUID: ${resource_uuid}"
               echo "- ${label} image: ${image_uri}"
               echo "- ${label} image tag: ${image_tag}"
+              echo "- ${label} Coolify image tag: ${tag}"
             } >> "$GITHUB_STEP_SUMMARY"
           }
 

--- a/.github/workflows/deploy-mcp-server.yml
+++ b/.github/workflows/deploy-mcp-server.yml
@@ -204,6 +204,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          image_name="${MCP_IMAGE_TAG%:*}"
+          tag="${MCP_IMAGE_TAG##*:}"
+
+          curl --fail --show-error --silent \
+            --request PATCH "${COOLIFY_API_URL}/applications/${COOLIFY_RESOURCE_UUID}" \
+            --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "$(printf '{"docker_registry_image_name":"%s","docker_registry_image_tag":"%s"}' "$image_name" "$tag")"
+
           curl --fail --show-error --silent \
             --request POST "${COOLIFY_API_URL}/deploy?uuid=${COOLIFY_RESOURCE_UUID}&force=false" \
             --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
@@ -214,6 +223,7 @@ jobs:
             echo "- Coolify app UUID: ${COOLIFY_RESOURCE_UUID}"
             echo "- Image URI: ${MCP_IMAGE_URI}"
             echo "- Image tag: ${MCP_IMAGE_TAG}"
+            echo "- Coolify image tag: ${tag}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   scan-image:

--- a/.github/workflows/quickvoice-ai-hotfix-deploy.yml
+++ b/.github/workflows/quickvoice-ai-hotfix-deploy.yml
@@ -35,6 +35,16 @@ jobs:
             exit 1
           fi
 
+          image_without_digest="${AI_IMAGE%@*}"
+          image_name="${image_without_digest%:*}"
+          tag="${image_without_digest##*:}"
+
+          curl --fail --show-error --silent \
+            --request PATCH "${COOLIFY_API_URL}/applications/${COOLIFY_QUICKVOICE_AI_RESOURCE_UUID}" \
+            --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "$(printf '{"docker_registry_image_name":"%s","docker_registry_image_tag":"%s"}' "$image_name" "$tag")"
+
           curl --fail --show-error --silent \
             --request POST "${COOLIFY_API_URL}/deploy?uuid=${COOLIFY_QUICKVOICE_AI_RESOURCE_UUID}&force=false" \
             --header "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
@@ -44,4 +54,5 @@ jobs:
             echo "## QuickVoice AI hotfix deploy"
             echo "- Coolify AI app UUID: ${COOLIFY_QUICKVOICE_AI_RESOURCE_UUID}"
             echo "- Requested AI image: ${AI_IMAGE}"
+            echo "- Coolify image tag: ${tag}"
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
Patch Docker-image app image name/tag in Coolify before triggering deployments, so sha-tagged ECR builds are actually deployed for server, AI, MCP, and AI hotfix runs.