### PR TITLE
chore: refresh all QuickVoice services

### DIFF
--- a/apps/ai/.deploy-refresh
+++ b/apps/ai/.deploy-refresh
@@ -1,0 +1,2 @@
+QuickVoice deployment refresh marker.
+Last refresh request: 2026-08-12T08:30:00Z

--- a/apps/console/.deploy-refresh
+++ b/apps/console/.deploy-refresh
@@ -1,0 +1,2 @@
+QuickVoice deployment refresh marker.
+Last refresh request: 2026-08-12T08:30:00Z

--- a/apps/docs/.deploy-refresh
+++ b/apps/docs/.deploy-refresh
@@ -1,0 +1,2 @@
+QuickVoice deployment refresh marker.
+Last refresh request: 2026-08-12T08:30:00Z

--- a/apps/mcp-server/.deploy-refresh
+++ b/apps/mcp-server/.deploy-refresh
@@ -1,0 +1,2 @@
+QuickVoice deployment refresh marker.
+Last refresh request: 2026-08-12T08:30:00Z

--- a/apps/server/.deploy-refresh
+++ b/apps/server/.deploy-refresh
@@ -1,0 +1,2 @@
+QuickVoice deployment refresh marker.
+Last refresh request: 2026-08-12T08:30:00Z

--- a/apps/web/.deploy-refresh
+++ b/apps/web/.deploy-refresh
@@ -1,0 +1,2 @@
+QuickVoice deployment refresh marker.
+Last refresh request: 2026-08-12T08:30:00Z


### PR DESCRIPTION
Add no-op per-app refresh markers to force backend, AI, MCP, web, console, and docs deployment paths after ECR auth was fixed.