### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ If QuickVoice helps you evaluate open voice-agent infrastructure, a GitHub star 
 
 [Star QuickVoice on GitHub](https://github.com/allgpt-co/QuickVoice)
 
-[![QuickVoice Star History](https://api.star-history.com/svg?repos=allgpt-co/QuickVoice&type=Date)](https://www.star-history.com/#allgpt-co/QuickVoice&Date)
+[![QuickVoice Star History](https://star-history.dera.page/svg?repos=allgpt-co/QuickVoice&type=Date)](https://star-history.dera.page/#allgpt-co/QuickVoice&Date)
 
 ## Community
 


### PR DESCRIPTION
The star history chart on the README is currently broken because the provider stopped working reliably under GitHub stargazer API restrictions. This change points the chart to the dera.page service, which uses a data source that requires no API token and serves both the SVG image and the interactive chart from the same domain. This restores the star history chart for QuickVoice.