### PR TITLE
Deliver website enquiries through the existing email service

### DIFF
--- a/apps/server/.env.dev.example
+++ b/apps/server/.env.dev.example
@@ -85,6 +85,14 @@ SMTP_PORT=1025
 SMTP_USERNAME=dev
 SMTP_PASSWORD=dev
 FROM_EMAIL=no-reply@localhost
+# Optional ZeptoMail HTTP transport; when set, it takes precedence over SMTP.
+ZEPTOMAIL_TOKEN=
+ZEPTOMAIL_URL=
+# Enables authenticated POST /api/${API_VERSION}/contact-delivery. Generate a
+# dedicated random secret, for example: openssl rand -hex 32. Match the web secret.
+CONTACT_WEBHOOK_SECRET=
+# Optional single recipient for self-hosters. Blank defaults to info@quickvoice.co.
+CONTACT_RECIPIENT_EMAIL=
 
 SMITHERY_NAMESPACE=quickvoice
 SMITHERY_API_KEY=dev-smithery-key

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -20,6 +20,7 @@ import { inngestFunctions } from "./inngest/index.js";
 import apiRouter from "./router.js";
 import { getReadiness } from "./modules/system/readiness.service.js";
 import systemRuntimeRouter from "./modules/system/runtime.route.js";
+import contactRouter from "./modules/contact/contact.route.js";
 import { publicWidgetOriginAllowed } from "./modules/widgets/widget.service.js";
 import "./workers/kb.worker.js";
 import "./workers/outbound-batch.worker.js";
@@ -162,6 +163,10 @@ app.use(`/api/${apiVersion}/system`, systemRuntimeRouter);
 // Rate limit before JSON parsing so oversized or abusive request bodies are
 // throttled before the server spends work parsing them.
 app.use(rateLimitMiddleware);
+
+// Authenticate contact forwarding before its bounded JSON parser. Keep this
+// separate from session auth and mount it under the configured API version.
+app.use(`/api/${apiVersion}`, contactRouter);
 
 // Body parser (after Better Auth handler)
 app.use(express.json());

--- a/apps/server/src/lib/mailer.ts
+++ b/apps/server/src/lib/mailer.ts
@@ -1,4 +1,10 @@
 import nodemailer from "nodemailer";
+import {
+  contactEmailAddressSchema,
+  type ContactSubmission,
+} from "../modules/contact/contact.schema.js";
+
+export const CONTACT_DELIVERY_TIMEOUT_MS = 8_000;
 
 type AuthEmailType = "verifyEmail" | "resetPassword";
 
@@ -20,7 +26,9 @@ function requireEnv(name: string) {
 function getZeptoMailToken() {
   const token = process.env.ZEPTOMAIL_TOKEN;
   if (!token) {
-    throw new Error("Missing required email environment variable: ZEPTOMAIL_TOKEN");
+    throw new Error(
+      "Missing required email environment variable: ZEPTOMAIL_TOKEN",
+    );
   }
   const trimmedToken = token.trim();
   if (/^zoho-enczapikey\s+/i.test(trimmedToken)) {
@@ -30,7 +38,8 @@ function getZeptoMailToken() {
 }
 
 function getZeptoMailEndpoint() {
-  const rawUrl = process.env.ZEPTOMAIL_URL || process.env.SMTP_HOST || "api.zeptomail.com";
+  const rawUrl =
+    process.env.ZEPTOMAIL_URL || process.env.SMTP_HOST || "api.zeptomail.com";
 
   const urlWithProtocol = /^https?:\/\//i.test(rawUrl)
     ? rawUrl
@@ -65,7 +74,7 @@ function getSmtpPort() {
   return port;
 }
 
-function getSmtpTransport() {
+function getSmtpTransport(timeoutMs?: number) {
   const port = getSmtpPort();
   return nodemailer.createTransport({
     host: requireEnv("SMTP_HOST"),
@@ -75,7 +84,38 @@ function getSmtpTransport() {
       user: requireEnv("SMTP_USERNAME"),
       pass: requireEnv("SMTP_PASSWORD"),
     },
+    ...(timeoutMs
+      ? {
+          connectionTimeout: timeoutMs,
+          greetingTimeout: timeoutMs,
+          socketTimeout: timeoutMs,
+          dnsTimeout: timeoutMs,
+        }
+      : {}),
   });
+}
+
+async function withDeliveryTimeout<T>(
+  send: (signal?: AbortSignal) => Promise<T>,
+  timeoutMs?: number,
+  close?: () => void,
+): Promise<T> {
+  if (!timeoutMs) return send();
+
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error("Email provider timed out; delivery status is unknown"));
+      controller.abort();
+      close?.();
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([send(controller.signal), deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function escapeHtml(value: string) {
@@ -92,7 +132,8 @@ function contentFor(type: AuthEmailType): EmailContent {
     return {
       subject: "Verify your QuickVoice email",
       heading: "Verify your email",
-      intro: "Confirm your email address to finish setting up your QuickVoice account.",
+      intro:
+        "Confirm your email address to finish setting up your QuickVoice account.",
       action: "Verify email",
     };
   }
@@ -171,8 +212,7 @@ export async function sendNumberBillingNotice(args: {
   priceUsd: string;
 }) {
   const billingUrl = `${(
-    process.env.CONSOLE_URL?.split(",")[0]?.trim() ||
-    "http://localhost:3000"
+    process.env.CONSOLE_URL?.split(",")[0]?.trim() || "http://localhost:3000"
   ).replace(/\/+$/, "")}/settings/billing`;
   const date = args.chargeDate.toISOString().slice(0, 10);
   const subject = "Your QuickVoice number moves to prepaid billing in 7 days";
@@ -196,6 +236,39 @@ export async function sendNumberBillingNotice(args: {
   });
 }
 
+export async function sendContactSubmission(submission: ContactSubmission) {
+  const recipient = contactEmailAddressSchema.parse(
+    process.env.CONTACT_RECIPIENT_EMAIL?.trim() || "info@quickvoice.co",
+  );
+  const replyTo = contactEmailAddressSchema.parse(submission.email);
+  const fields: Array<[string, string]> = [
+    ["Name", submission.name],
+    ["Email", replyTo],
+    ["Company", submission.company || "Not provided"],
+    ["Phone", submission.phone || "Not provided"],
+    ["Looking for", submission.lookingFor],
+    ["Submitted at", submission.submittedAt],
+    ["Source", submission.source],
+    ["Message", submission.message],
+  ];
+  const text = fields
+    .map(([label, value]) => `${label}: ${value}`)
+    .join("\n\n");
+  const html = `<!doctype html><html><body><h1>New website enquiry</h1>${fields.map(([label, value]) => `<h2>${escapeHtml(label)}</h2><pre style="white-space:pre-wrap;font-family:Arial,sans-serif">${escapeHtml(value)}</pre>`).join("")}</body></html>`;
+
+  return sendComposedEmail({
+    email: recipient,
+    fullName: "QuickVoice team",
+    subject: "New QuickVoice website enquiry",
+    text,
+    html,
+    replyTo,
+    timeoutMs: CONTACT_DELIVERY_TIMEOUT_MS,
+    requireRecipientAcceptance: true,
+    failureLabel: "website contact",
+  });
+}
+
 async function sendComposedEmail(args: {
   email: string;
   fullName: string;
@@ -203,6 +276,9 @@ async function sendComposedEmail(args: {
   text: string;
   html: string;
   failureLabel: string;
+  replyTo?: string;
+  timeoutMs?: number;
+  requireRecipientAcceptance?: boolean;
 }) {
   const fromEmail = requireEnv("FROM_EMAIL");
   const fromName = "Console|Quickvoice";
@@ -223,25 +299,30 @@ async function sendComposedEmail(args: {
     subject: args.subject,
     textbody: args.text,
     htmlbody: args.html,
+    ...(args.replyTo ? { reply_to: [{ address: args.replyTo }] } : {}),
   };
 
   if (process.env.ZEPTOMAIL_TOKEN) {
     try {
-      const response = await fetch(getZeptoMailEndpoint(), {
-        method: "POST",
-        headers: {
-          Authorization: getZeptoMailToken(),
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-      });
-      const body = await response.text();
+      await withDeliveryTimeout(async (signal) => {
+        const response = await fetch(getZeptoMailEndpoint(), {
+          method: "POST",
+          headers: {
+            Authorization: getZeptoMailToken(),
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+          ...(signal ? { signal } : {}),
+        });
+        const body = await response.text();
 
-      if (!response.ok) {
-        throw new Error(
-          `ZeptoMail responded with ${response.status} ${response.statusText}: ${body}`,
-        );
-      }
+        if (!response.ok) {
+          throw new Error(
+            `ZeptoMail responded with ${response.status} ${response.statusText}: ${body}`,
+          );
+        }
+        return response;
+      }, args.timeoutMs);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
@@ -252,21 +333,38 @@ async function sendComposedEmail(args: {
   }
 
   try {
-    await getSmtpTransport().sendMail({
-      from: {
-        address: fromEmail,
-        name: fromName,
-      },
-      to: [
-        {
-          address: args.email,
-          name: args.fullName,
-        },
-      ],
-      subject: args.subject,
-      text: args.text,
-      html: args.html,
-    });
+    const transport = getSmtpTransport(args.timeoutMs);
+    const result = await withDeliveryTimeout(
+      () =>
+        transport.sendMail({
+          from: {
+            address: fromEmail,
+            name: fromName,
+          },
+          to: [
+            {
+              address: args.email,
+              name: args.fullName,
+            },
+          ],
+          subject: args.subject,
+          text: args.text,
+          html: args.html,
+          ...(args.replyTo ? { replyTo: { address: args.replyTo } } : {}),
+        }),
+      args.timeoutMs,
+      () => transport.close(),
+    );
+    if (
+      args.requireRecipientAcceptance &&
+      !result.accepted?.some(
+        (value) =>
+          (typeof value === "string" ? value : value.address).toLowerCase() ===
+          args.email.toLowerCase(),
+      )
+    ) {
+      throw new Error("SMTP did not acknowledge the contact recipient");
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(

--- a/apps/server/src/modules/contact/contact.route.ts
+++ b/apps/server/src/modules/contact/contact.route.ts
@@ -1,0 +1,72 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import {
+  json,
+  Router,
+  type ErrorRequestHandler,
+  type RequestHandler,
+} from "express";
+
+import { sendContactSubmission } from "../../lib/mailer.js";
+import { contactSubmissionSchema } from "./contact.schema.js";
+
+const router = Router();
+
+const authenticateContact: RequestHandler = (req, res, next) => {
+  const secret = process.env.CONTACT_WEBHOOK_SECRET?.trim();
+  if (!secret || secret.length < 32) {
+    res.status(503).json({ error: "Contact delivery is not configured" });
+    return;
+  }
+
+  const supplied = req.get("X-QuickVoice-Contact-Secret") || "";
+  // Fixed-size digests permit constant-time comparison even for unequal lengths.
+  const digest = (value: string) => createHash("sha256").update(value).digest();
+  if (!timingSafeEqual(digest(supplied), digest(secret))) {
+    res.status(401).json({ error: "Unauthorized contact delivery" });
+    return;
+  }
+
+  next();
+};
+
+router.post(
+  "/contact-delivery",
+  authenticateContact,
+  json({ limit: "32kb" }),
+  async (req, res) => {
+    const parsed = contactSubmissionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid contact submission" });
+      return;
+    }
+
+    try {
+      await sendContactSubmission(parsed.data);
+    } catch {
+      // Provider responses can contain submitted personal data. Keep them out of
+      // public responses and logs; never retry an ambiguous delivery automatically.
+      console.error("Contact email delivery failed");
+      res
+        .status(502)
+        .json({ error: "Contact email delivery could not be confirmed" });
+      return;
+    }
+
+    res.status(200).json({ ok: true });
+  },
+);
+
+const parseError: ErrorRequestHandler = (error, _req, res, next) => {
+  if (error?.type === "entity.parse.failed") {
+    res.status(400).json({ error: "Invalid contact JSON" });
+    return;
+  }
+  if (error?.type === "entity.too.large") {
+    res.status(413).json({ error: "Contact submission is too large" });
+    return;
+  }
+  next(error);
+};
+router.use("/contact-delivery", parseError);
+
+export default router;

--- a/apps/server/src/modules/contact/contact.schema.ts
+++ b/apps/server/src/modules/contact/contact.schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+// A single mailbox only: never accept display names, address lists or headers.
+export const contactEmailAddressSchema = z.string().trim().max(254).email();
+
+export const contactSubmissionSchema = z.strictObject({
+  name: z.string().trim().min(2).max(120),
+  email: contactEmailAddressSchema.transform((value) => value.toLowerCase()),
+  company: z.string().trim().max(160),
+  phone: z
+    .string()
+    .trim()
+    .max(40)
+    .refine(
+      (value) => !value || /^[+]?[1-9][\d\s().-]{3,24}$/.test(value),
+      "Invalid phone number",
+    ),
+  lookingFor: z.string().trim().min(1).max(120),
+  message: z.string().trim().min(10).max(5000),
+  source: z.literal("quickvoice-web-contact"),
+  submittedAt: z.iso.datetime(),
+});
+
+export type ContactSubmission = z.infer<typeof contactSubmissionSchema>;

--- a/apps/server/tests/contact/contact-delivery.route.test.ts
+++ b/apps/server/tests/contact/contact-delivery.route.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import type { Server } from "node:http";
+import express from "express";
+
+import contactRouter from "../../src/modules/contact/contact.route.js";
+import { requestJson } from "../helpers/http-client.js";
+
+const secret = "contact-test-secret-at-least-32-characters";
+const submission = {
+  name: "Ada <script>alert('test')</script>",
+  email: "ada@example.com",
+  company: "A & B",
+  phone: "+1 (202) 555-0100",
+  lookingFor: "Pilot evaluation",
+  message:
+    "Please review <img src=x onerror=alert(1)> as plain text.\nSecond line.",
+  source: "quickvoice-web-contact",
+  submittedAt: "2026-09-06T12:00:00.000Z",
+};
+let server: Server;
+let baseUrl: string;
+const originalEnv = { ...process.env };
+
+before(async () => {
+  process.env.CONTACT_WEBHOOK_SECRET = secret;
+  delete process.env.CONTACT_RECIPIENT_EMAIL;
+  process.env.FROM_EMAIL = "verified@example.com";
+  process.env.ZEPTOMAIL_TOKEN = "provider-test-token";
+  process.env.ZEPTOMAIL_URL = "https://api.zeptomail.com";
+  const app = express();
+  // The router is relative to index.ts's configured API_VERSION mount.
+  app.use("/api/test-version", contactRouter);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  baseUrl = `http://127.0.0.1:${address.port}/api/test-version/contact-delivery`;
+});
+
+after(async () => {
+  process.env = originalEnv;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+function post(body: unknown = submission, suppliedSecret?: string) {
+  return requestJson(baseUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(suppliedSecret === undefined
+        ? {}
+        : { "X-QuickVoice-Contact-Secret": suppliedSecret }),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+test("contact delivery fails closed before sending when the secret is unavailable or wrong", async (t) => {
+  const fetch = t.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response(null, { status: 200 }),
+  );
+  delete process.env.CONTACT_WEBHOOK_SECRET;
+  assert.equal((await post(submission, secret)).status, 503);
+  process.env.CONTACT_WEBHOOK_SECRET = "too-short";
+  assert.equal((await post(submission, "too-short")).status, 503);
+  process.env.CONTACT_WEBHOOK_SECRET = secret;
+  for (const supplied of [
+    undefined,
+    "wrong",
+    "x".repeat(secret.length),
+    `${secret}, ${secret}`,
+  ]) {
+    assert.equal((await post(submission, supplied)).status, 401);
+  }
+  assert.equal(fetch.mock.callCount(), 0);
+});
+
+test("contact delivery revalidates content and rejects recipient/header injection", async (t) => {
+  const fetch = t.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response(null, { status: 200 }),
+  );
+  for (const body of [
+    null,
+    [],
+    {},
+    { ...submission, name: "A" },
+    { ...submission, message: "x".repeat(5001) },
+    { ...submission, message: "short" },
+    { ...submission, email: "ada@example.com\r\nBcc: victim@example.com" },
+    { ...submission, email: "ada@example.com,victim@example.com" },
+    { ...submission, email: "Ada <ada@example.com>" },
+    { ...submission, phone: "not a phone" },
+    { ...submission, source: "arbitrary-client" },
+    { ...submission, submittedAt: "not a timestamp" },
+    { ...submission, to: "victim@example.com" },
+    { ...submission, recipient: "victim@example.com" },
+    { ...submission, replyTo: "victim@example.com" },
+  ]) {
+    assert.equal((await post(body, secret)).status, 400);
+  }
+  assert.equal(fetch.mock.callCount(), 0);
+});
+
+test("contact JSON parsing is bounded and happens only after authentication", async (t) => {
+  const fetch = t.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response("{}", { status: 200 }),
+  );
+  for (const [body, expected] of [
+    ["{broken", 400],
+    [JSON.stringify({ message: "x".repeat(40_000) }), 413],
+  ] as const) {
+    for (const supplied of [undefined, secret]) {
+      const response = await requestJson(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(supplied ? { "X-QuickVoice-Contact-Secret": supplied } : {}),
+        },
+        body,
+      });
+      assert.equal(response.status, supplied ? expected : 401);
+    }
+  }
+  assert.equal(fetch.mock.callCount(), 0);
+});
+
+test("authenticated contact uses the fixed recipient, verified sender, Reply-To and escaped body", async (t) => {
+  const fetch = t.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response("{}", { status: 200 }),
+  );
+  const response = await post(submission, secret);
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true });
+  assert.equal(fetch.mock.callCount(), 1);
+  const init = fetch.mock.calls[0]!.arguments[1] as RequestInit;
+  const message = JSON.parse(init.body as string);
+  assert.deepEqual(message.to, [
+    {
+      email_address: { address: "info@quickvoice.co", name: "QuickVoice team" },
+    },
+  ]);
+  assert.equal(message.from.address, "verified@example.com");
+  assert.deepEqual(message.reply_to, [{ address: submission.email }]);
+  assert.equal(message.subject, "New QuickVoice website enquiry");
+  assert.ok(message.textbody.includes(submission.message));
+  assert.match(message.htmlbody, /&lt;img src=x onerror=alert\(1\)&gt;/);
+  assert.match(message.htmlbody, /A &amp; B/);
+  assert.doesNotMatch(message.htmlbody, /<script|<img/);
+  assert.equal(init.signal?.aborted, false);
+});
+
+test("provider rejection produces one controlled failure, no retry and no leaked provider data", async (t) => {
+  const fetch = t.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response("private-provider-response", { status: 500 }),
+  );
+  const log = t.mock.method(console, "error", () => {});
+  const response = await post(submission, secret);
+  assert.equal(response.status, 502);
+  assert.deepEqual(await response.json(), {
+    error: "Contact email delivery could not be confirmed",
+  });
+  assert.equal(fetch.mock.callCount(), 1);
+  assert.deepEqual(log.mock.calls[0]!.arguments, [
+    "Contact email delivery failed",
+  ]);
+});

--- a/apps/server/tests/contact/contact-mailer.test.ts
+++ b/apps/server/tests/contact/contact-mailer.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import nodemailer from "nodemailer";
+
+import {
+  CONTACT_DELIVERY_TIMEOUT_MS,
+  sendContactSubmission,
+} from "../../src/lib/mailer.js";
+import type { ContactSubmission } from "../../src/modules/contact/contact.schema.js";
+
+const originalEnv = { ...process.env };
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+const submission: ContactSubmission = {
+  name: "Contact Test",
+  email: "visitor@example.com",
+  company: "",
+  phone: "",
+  lookingFor: "Evaluation",
+  message: "Please discuss a test evaluation.",
+  source: "quickvoice-web-contact",
+  submittedAt: "2026-09-06T12:00:00.000Z",
+};
+
+function setSmtpEnv() {
+  delete process.env.ZEPTOMAIL_TOKEN;
+  delete process.env.CONTACT_RECIPIENT_EMAIL;
+  process.env.FROM_EMAIL = "verified@example.com";
+  process.env.SMTP_HOST = "smtp.example.com";
+  process.env.SMTP_USERNAME = "test-user";
+  process.env.SMTP_PASSWORD = "test-password";
+}
+
+test("contact SMTP keeps the sender fixed and accepts only its configured recipient", async (t) => {
+  setSmtpEnv();
+  process.env.CONTACT_RECIPIENT_EMAIL = "selfhost@example.com";
+  let sent: nodemailer.SendMailOptions | undefined;
+  let options: Record<string, unknown> | undefined;
+  t.mock.method(nodemailer, "createTransport", ((
+    config: Record<string, unknown>,
+  ) => {
+    options = config;
+    return {
+      sendMail: async (message: nodemailer.SendMailOptions) => {
+        sent = message;
+        return { accepted: ["selfhost@example.com"] };
+      },
+      close: () => {},
+    };
+  }) as typeof nodemailer.createTransport);
+  await sendContactSubmission(submission);
+  assert.deepEqual(sent?.from, {
+    address: "verified@example.com",
+    name: "Console|Quickvoice",
+  });
+  assert.deepEqual(sent?.to, [
+    { address: "selfhost@example.com", name: "QuickVoice team" },
+  ]);
+  assert.deepEqual(sent?.replyTo, { address: "visitor@example.com" });
+  for (const setting of [
+    "connectionTimeout",
+    "greetingTimeout",
+    "socketTimeout",
+    "dnsTimeout",
+  ]) {
+    assert.equal(options?.[setting], CONTACT_DELIVERY_TIMEOUT_MS);
+  }
+  assert.ok(CONTACT_DELIVERY_TIMEOUT_MS < 10_000);
+});
+
+test("invalid configured recipients and Reply-To fail before invoking a mail provider", async (t) => {
+  setSmtpEnv();
+  const transport = t.mock.method(nodemailer, "createTransport", (() => {
+    throw new Error("Must not send");
+  }) as typeof nodemailer.createTransport);
+  process.env.CONTACT_RECIPIENT_EMAIL = "one@example.com,two@example.com";
+  await assert.rejects(sendContactSubmission(submission));
+  delete process.env.CONTACT_RECIPIENT_EMAIL;
+  await assert.rejects(
+    sendContactSubmission({
+      ...submission,
+      email: "visitor@example.com\r\nBcc: other@example.com",
+    }),
+  );
+  assert.equal(transport.mock.callCount(), 0);
+});
+
+test("a resolved SMTP operation with no accepted recipient is a failed delivery", async (t) => {
+  setSmtpEnv();
+  t.mock.method(nodemailer, "createTransport", (() => ({
+    sendMail: async () => ({ accepted: [], rejected: ["info@quickvoice.co"] }),
+    close: () => {},
+  })) as unknown as typeof nodemailer.createTransport);
+  await assert.rejects(
+    sendContactSubmission(submission),
+    /SMTP did not acknowledge/,
+  );
+});
+
+test("SMTP wait is bounded below the web deadline and never retries an ambiguous send", async (t) => {
+  setSmtpEnv();
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let attempts = 0;
+  let closed = 0;
+  t.mock.method(nodemailer, "createTransport", (() => ({
+    sendMail: async () => {
+      attempts++;
+      return new Promise(() => {});
+    },
+    close: () => {
+      closed++;
+    },
+  })) as unknown as typeof nodemailer.createTransport);
+  const pending = sendContactSubmission(submission);
+  const rejected = assert.rejects(
+    pending,
+    /timed out; delivery status is unknown/,
+  );
+  t.mock.timers.tick(CONTACT_DELIVERY_TIMEOUT_MS);
+  await rejected;
+  assert.equal(attempts, 1);
+  assert.equal(closed, 1);
+});
+
+test("ZeptoMail timeout aborts its one request without retrying or falling back to SMTP", async (t) => {
+  setSmtpEnv();
+  process.env.ZEPTOMAIL_TOKEN = "test-token";
+  process.env.ZEPTOMAIL_URL = "https://api.zeptomail.com";
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let signal: AbortSignal | null | undefined;
+  const fetch = t.mock.method(globalThis, "fetch", async (_url, init) => {
+    signal = init?.signal;
+    return new Promise<Response>(() => {});
+  });
+  const transport = t.mock.method(nodemailer, "createTransport", (() => {
+    throw new Error("No fallback");
+  }) as typeof nodemailer.createTransport);
+  const pending = sendContactSubmission(submission);
+  const rejected = assert.rejects(
+    pending,
+    /timed out; delivery status is unknown/,
+  );
+  t.mock.timers.tick(CONTACT_DELIVERY_TIMEOUT_MS);
+  await rejected;
+  assert.equal(signal?.aborted, true);
+  assert.equal(fetch.mock.callCount(), 1);
+  assert.equal(transport.mock.callCount(), 0);
+});

--- a/apps/web/.env.dev.example
+++ b/apps/web/.env.dev.example
@@ -5,3 +5,7 @@ NEXT_PUBLIC_GA_MEASUREMENT_ID=
 NEXT_PUBLIC_GSC_VERIFICATION=
 # Contact forms return 503 until an accepting server-side webhook is configured.
 CONTACT_WEBHOOK_URL=
+# When using the server's /api/v1/contact-delivery endpoint, set the same random
+# secret (at least 32 characters) on web and server. Never prefix it NEXT_PUBLIC_.
+# Leave blank for an existing external webhook that does not use this header.
+CONTACT_WEBHOOK_SECRET=

--- a/apps/web/src/app/api/contact/route.ts
+++ b/apps/web/src/app/api/contact/route.ts
@@ -20,9 +20,9 @@ function cleanString(value: unknown, maxLength: number): string {
   return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
 }
 
-function parseSubmission(body: unknown):
-  | { ok: true; submission: ContactSubmission }
-  | { ok: false; error: string } {
+function parseSubmission(
+  body: unknown,
+): { ok: true; submission: ContactSubmission } | { ok: false; error: string } {
   if (!body || typeof body !== "object") {
     return { ok: false, error: "Invalid request payload" };
   }
@@ -70,10 +70,19 @@ function parseSubmission(body: unknown):
   };
 }
 
-async function forwardSubmission(submission: ContactSubmission, webhookUrl: string) {
+async function forwardSubmission(
+  submission: ContactSubmission,
+  webhookUrl: string,
+) {
+  const secret = process.env.CONTACT_WEBHOOK_SECRET?.trim();
   const response = await fetch(webhookUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(secret ? { "X-QuickVoice-Contact-Secret": secret } : {}),
+    },
+    // Do not carry the shared credential to a redirected destination.
+    ...(secret ? { redirect: "error" as const } : {}),
     body: JSON.stringify(submission),
     signal: AbortSignal.timeout(10_000),
   });
@@ -103,7 +112,10 @@ export async function POST(request: NextRequest) {
   const webhookUrl = process.env.CONTACT_WEBHOOK_URL?.trim();
   if (!webhookUrl) {
     return NextResponse.json(
-      { error: "Contact delivery is temporarily unavailable. Please email info@quickvoice.co directly." },
+      {
+        error:
+          "Contact delivery is temporarily unavailable. Please email info@quickvoice.co directly.",
+      },
       { status: 503 },
     );
   }

--- a/apps/web/tests/contact-delivery.test.mjs
+++ b/apps/web/tests/contact-delivery.test.mjs
@@ -7,22 +7,56 @@ const require = createRequire(import.meta.url);
 const ts = require("typescript");
 const routeUrl = new URL("../src/app/api/contact/route.ts", import.meta.url);
 const source = readFileSync(routeUrl, "utf8");
-const output = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS } }).outputText;
+const output = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS },
+}).outputText;
 const compiledModule = { exports: {} };
-new Function("require", "module", "exports", output)(createRequire(routeUrl), compiledModule, compiledModule.exports);
+new Function("require", "module", "exports", output)(
+  createRequire(routeUrl),
+  compiledModule,
+  compiledModule.exports,
+);
 const { POST } = compiledModule.exports;
-const analyticsSource = readFileSync(new URL("../src/lib/analytics.ts", import.meta.url), "utf8");
-const analyticsOutput = ts.transpileModule(analyticsSource, { compilerOptions: { module: ts.ModuleKind.CommonJS } }).outputText;
+const analyticsSource = readFileSync(
+  new URL("../src/lib/analytics.ts", import.meta.url),
+  "utf8",
+);
+const analyticsOutput = ts.transpileModule(analyticsSource, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS },
+}).outputText;
 const analyticsModule = { exports: {} };
-new Function("module", "exports", analyticsOutput)(analyticsModule, analyticsModule.exports);
+new Function("module", "exports", analyticsOutput)(
+  analyticsModule,
+  analyticsModule.exports,
+);
 const { trackContactLead } = analyticsModule.exports;
-const payload = { name: "Test Person", email: "test@example.com", lookingFor: "Evaluation", message: "Please discuss our requirements." };
+const payload = {
+  name: "Test Person",
+  email: "test@example.com",
+  lookingFor: "Evaluation",
+  message: "Please discuss our requirements.",
+};
 const request = (body = payload) => ({ json: async () => body });
 
 test("contact success requires acknowledged webhook delivery", async (t) => {
   const previous = process.env.CONTACT_WEBHOOK_URL;
-  t.after(() => previous === undefined ? delete process.env.CONTACT_WEBHOOK_URL : process.env.CONTACT_WEBHOOK_URL = previous);
-  const fetch = t.mock.method(globalThis, "fetch", async () => new Response(null, { status: 204 }));
+  const previousSecret = process.env.CONTACT_WEBHOOK_SECRET;
+  t.after(() =>
+    previous === undefined
+      ? delete process.env.CONTACT_WEBHOOK_URL
+      : (process.env.CONTACT_WEBHOOK_URL = previous),
+  );
+  t.after(() =>
+    previousSecret === undefined
+      ? delete process.env.CONTACT_WEBHOOK_SECRET
+      : (process.env.CONTACT_WEBHOOK_SECRET = previousSecret),
+  );
+  delete process.env.CONTACT_WEBHOOK_SECRET;
+  const fetch = t.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response(null, { status: 204 }),
+  );
   t.mock.method(console, "error", () => {});
 
   delete process.env.CONTACT_WEBHOOK_URL;
@@ -36,27 +70,125 @@ test("contact success requires acknowledged webhook delivery", async (t) => {
   assert.equal(response.status, 200);
   assert.equal((await response.json()).ok, true);
   assert.equal(fetch.mock.callCount(), 1);
+  assert.deepEqual(fetch.mock.calls[0].arguments[1].headers, {
+    "Content-Type": "application/json",
+  });
+  assert.equal(fetch.mock.calls[0].arguments[1].redirect, undefined);
 
-  fetch.mock.mockImplementation(async () => new Response(null, { status: 500 }));
+  fetch.mock.mockImplementation(
+    async () => new Response(null, { status: 500 }),
+  );
   response = await POST(request());
   assert.equal(response.status, 502);
   assert.notEqual((await response.json()).ok, true);
 
-  fetch.mock.mockImplementation(async () => { throw new Error("Network unavailable"); });
+  fetch.mock.mockImplementation(async () => {
+    throw new Error("Network unavailable");
+  });
   assert.equal((await POST(request())).status, 502);
-  assert.equal((await POST(request({ ...payload, email: "invalid" }))).status, 400);
-  assert.equal((await POST({ json: async () => { throw new SyntaxError("bad JSON"); } })).status, 400);
+  assert.equal(
+    (await POST(request({ ...payload, email: "invalid" }))).status,
+    400,
+  );
+  assert.equal(
+    (
+      await POST({
+        json: async () => {
+          throw new SyntaxError("bad JSON");
+        },
+      })
+    ).status,
+    400,
+  );
+});
+
+test("contact forwarding adds only the server-configured secret and rejects authenticated redirects", async (t) => {
+  const previousUrl = process.env.CONTACT_WEBHOOK_URL;
+  const previousSecret = process.env.CONTACT_WEBHOOK_SECRET;
+  t.after(() =>
+    previousUrl === undefined
+      ? delete process.env.CONTACT_WEBHOOK_URL
+      : (process.env.CONTACT_WEBHOOK_URL = previousUrl),
+  );
+  t.after(() =>
+    previousSecret === undefined
+      ? delete process.env.CONTACT_WEBHOOK_SECRET
+      : (process.env.CONTACT_WEBHOOK_SECRET = previousSecret),
+  );
+  process.env.CONTACT_WEBHOOK_URL =
+    "https://api.example.com/api/v1/contact-delivery";
+  process.env.CONTACT_WEBHOOK_SECRET =
+    " server-configured-contact-secret-32chars ";
+  const fetch = t.mock.method(
+    globalThis,
+    "fetch",
+    async () => new Response(null, { status: 200 }),
+  );
+  t.mock.method(console, "error", () => {});
+  const response = await POST(
+    request({
+      ...payload,
+      to: "other@example.com",
+      secret: "visitor-controlled",
+    }),
+  );
+  assert.equal(response.status, 200);
+  const [url, init] = fetch.mock.calls[0].arguments;
+  assert.equal(url, process.env.CONTACT_WEBHOOK_URL);
+  assert.equal(
+    init.headers["X-QuickVoice-Contact-Secret"],
+    "server-configured-contact-secret-32chars",
+  );
+  assert.equal(init.redirect, "error");
+  const body = JSON.parse(init.body);
+  assert.equal(body.source, "quickvoice-web-contact");
+  assert.equal(body.to, undefined);
+  assert.equal(body.secret, undefined);
+  assert.equal(
+    JSON.stringify(await response.json()).includes("server-configured"),
+    false,
+  );
+
+  fetch.mock.mockImplementation(
+    async () => new Response(null, { status: 401 }),
+  );
+  const failed = await POST(request());
+  assert.equal(failed.status, 502);
+  assert.notEqual((await failed.json()).ok, true);
+  assert.equal(fetch.mock.callCount(), 2);
 });
 
 test("lead analytics sends only fixed form context and remains optional", (t) => {
   const previousWindow = globalThis.window;
-  t.after(() => previousWindow === undefined ? delete globalThis.window : globalThis.window = previousWindow);
+  t.after(() =>
+    previousWindow === undefined
+      ? delete globalThis.window
+      : (globalThis.window = previousWindow),
+  );
   delete globalThis.window;
   assert.equal(trackContactLead("homepage"), false);
   const calls = [];
-  globalThis.window = { location: { pathname: "/company/contact", search: "?email=private@example.com" }, gtag: (...args) => calls.push(args) };
+  globalThis.window = {
+    location: {
+      pathname: "/company/contact",
+      search: "?email=private@example.com",
+    },
+    gtag: (...args) => calls.push(args),
+  };
   assert.equal(trackContactLead("contact_page"), true);
-  assert.deepEqual(calls, [["event", "generate_lead", { method: "contact_form", form_location: "contact_page", page_path: "/company/contact" }]]);
-  window.gtag = () => { throw new Error("Analytics blocked"); };
+  assert.deepEqual(calls, [
+    [
+      "event",
+      "generate_lead",
+      {
+        method: "contact_form",
+        form_location: "contact_page",
+        page_path: "/company/contact",
+      },
+    ],
+  ]);
+  window.gtag = () => {
+    throw new Error("Analytics blocked");
+  };
   assert.equal(trackContactLead("homepage"), false);
 });

--- a/docs/marketing/seo/contact-delivery-operations.md
+++ b/docs/marketing/seo/contact-delivery-operations.md
@@ -1,0 +1,32 @@
+# Website contact delivery
+
+The web contact handler can send enquiries through the API server's existing ZeptoMail/SMTP mailer. The API accepts only the expected contact fields, authenticates the web server with a dedicated shared secret, and sends to a server-configured single recipient. It does not accept a recipient, subject, sender or arbitrary mail options from the browser.
+
+## Configuration
+
+1. Keep the server's existing verified `FROM_EMAIL` and working mail transport. A nonempty `ZEPTOMAIL_TOKEN` selects the ZeptoMail HTTP API; otherwise `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME` and `SMTP_PASSWORD` select SMTP. The existing authentication and billing-email configuration and content are retained.
+2. Generate a dedicated random secret with `openssl rand -hex 32` and store the same value as `CONTACT_WEBHOOK_SECRET` in the **server-only** runtime environment of both web and API services. The API fails closed when this value is missing or shorter than 32 characters. Keep it out of `NEXT_PUBLIC_` variables, repository files, URLs and client-side scripts.
+3. Set the web service's `CONTACT_WEBHOOK_URL` to the API's direct HTTPS endpoint, for example `https://your-api-host/api/v1/contact-delivery`. Replace `v1` if the API uses another `API_VERSION`. Authenticated forwarding rejects redirects so the credential is not sent to a redirect target. For local evaluation use the directly reachable local API URL.
+4. The API recipient defaults to `info@quickvoice.co`. Self-hosters may set the API-only `CONTACT_RECIPIENT_EMAIL` to one valid mailbox. Neither this setting nor provider credentials belong in the web service. The submitted, validated email is used only as Reply-To; `FROM_EMAIL` remains the verified sender.
+5. Deploy/restart the API with its configuration, then configure and release the web service. Existing external webhooks remain compatible when the web secret is blank: no authentication header is added and their existing success contract is unchanged. The new API endpoint always requires its secret.
+
+The web sends `X-QuickVoice-Contact-Secret`; the API compares fixed-length secret digests using `timingSafeEqual`. The endpoint remains behind the API's existing global rate limiter and authenticates before its 32 KB JSON parser. Names, company, phone, topic, message, fixed source and ISO timestamp are validated again by the API. HTML values are escaped and a plain-text part is supplied.
+
+## Verification and failures
+
+Run from the repository root:
+
+```sh
+pnpm --filter server exec tsx --test tests/mailer.test.ts tests/contact/*.test.ts
+pnpm --filter web test
+pnpm --filter server check-types
+pnpm --filter server build
+```
+
+Tests intercept provider traffic. They verify authentication failures, rejected recipient/header injection, HTML escaping, SMTP acceptance, bounded delivery waits, no automatic retry and unchanged auth-email behavior. No test sends a real enquiry or Analytics event.
+
+API results: missing/short configured secret returns 503; wrong/missing request secret returns 401; invalid JSON/submission returns 400; oversized JSON returns 413; unconfirmed provider delivery returns 502; provider acceptance returns 200 with `ok: true`. The browser-facing web contract remains 400 for invalid input, 503 for missing webhook configuration, 502 for failed forwarding and 200 with the existing success message after acknowledgement. `generate_lead` continues to fire only on that success path.
+
+Contact delivery waits at most 8 seconds for a provider, below the web's 10-second timeout. ZeptoMail requests are aborted at the deadline; SMTP has bounded connection/greeting/socket/DNS waits plus an overall response deadline and transport cleanup. **A timeout can leave delivery status unknown**: an SMTP transaction or provider-accepted message cannot be recalled by an HTTP timeout. There is no automatic retry or fallback to another transport. Before a manual resend, inspect provider activity and the destination inbox to avoid duplicates.
+
+After deployment, perform one explicitly authorized enquiry with synthetic details and a unique test marker. Verify provider acceptance and actual arrival in the configured inbox; provider acceptance alone does not guarantee inbox placement. Check the Reply-To and formatting, then verify the browser's successful response and the expected Analytics event separately. Record only the marker, timestamps and outcome in the tracker; keep contact data, secrets and raw provider responses out of the repository. GA key-event registration remains a separate administrative action.

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
   "ui": "tui",
-  "globalEnv": ["CONTACT_WEBHOOK_URL", "NODE_ENV"],
+  "globalEnv": [
+    "CONTACT_WEBHOOK_URL",
+    "CONTACT_WEBHOOK_SECRET",
+    "CONTACT_RECIPIENT_EMAIL",
+    "NODE_ENV"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Website enquiries currently have no production delivery destination. Add a dedicated authenticated API endpoint that sends each accepted enquiry to info@quickvoice.co through the server's existing email provider. The website reports success only after provider acceptance, allowing its existing generate_lead event to represent a delivered enquiry.

The API fixes the recipient, validates the payload and Reply-To address, escapes HTML, authenticates before a bounded JSON parser, and limits contact delivery to eight seconds. It does not automatically retry an ambiguous provider result. The website's shared-secret header is optional for compatibility with existing unsecreted webhooks; secret-bearing requests refuse redirects.

## Verification

- Frozen dependency install; no dependency changes.
- 262 server tests, 28 web tests, and 13 focused contact/auth-mailer tests passed.
- Web/server lint and types, server build, and campaign claims audit across69files passed.
- Full required CI runs before merge. These checks cover the affected server/web paths in place of running the Docker/Python portions of pnpm ci:local locally.
- Environment examples and the contact-delivery operator guide document configuration, deployment order, verification, and rollback. task doctor is unavailable on this host because go-task/Corepack are missing.
- No visual UI changes or schema migrations. Existing authentication and billing mail behavior is covered by regression tests.

## Release notes

Configure the same dedicated CONTACT_WEBHOOK_SECRET on the API and website, and point CONTACT_WEBHOOK_URL directly at the versioned API contact-delivery endpoint. Reuse the configured verified mail sender. Production provider acceptance, actual inbox receipt, and GA reporting must be recorded separately after deployment.

Requested as part of the remaining SEO implementation plan. User selected info@quickvoice.co as the destination and authorized commit/PR/merge. No live enquiry was sent during local testing.
