### PR TITLE
Track page views across client-side navigation with staged activation

### DIFF
--- a/apps/web/.env.dev.example
+++ b/apps/web/.env.dev.example
@@ -2,6 +2,9 @@ NEXT_PUBLIC_CONSOLE_URL=http://localhost:3000
 # Blank uses G-SZFBG11VRP on quickvoice.co/www.quickvoice.co only (not localhost).
 # Set a G- ID to override on any host, or off to disable. Changes require a rebuild.
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
+# Keep false until GA Enhanced Measurement's browser-history pageviews are off.
+# Opt in with true only after verifying that setting; requires a rebuild.
+NEXT_PUBLIC_GA_MANUAL_PAGEVIEWS=false
 NEXT_PUBLIC_GSC_VERIFICATION=
 # Contact forms return 503 until an accepting server-side webhook is configured.
 CONTACT_WEBHOOK_URL=

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,16 +1,19 @@
 import { Inter } from "next/font/google";
-import Script from "next/script";
+import { Suspense } from "react";
 import "./globals.css";
 
 import type { Metadata } from "next";
 import Navbar from "@/components/landing/navbar";
 import { Footer } from "@/components/landing/footer";
 import { CtaAnalytics } from "@/components/cta-analytics";
-import { createGoogleAnalyticsScript } from "@/lib/google-analytics-config.mjs";
+import { GoogleAnalytics } from "@/components/google-analytics";
+import { createGoogleAnalyticsScript, manualPageviewsEnabled } from "@/lib/google-analytics-config.mjs";
 const inter = Inter({ subsets: ["latin"], display: "swap" });
 
+const manualPageviews = manualPageviewsEnabled(process.env.NEXT_PUBLIC_GA_MANUAL_PAGEVIEWS);
 const googleAnalyticsScript = createGoogleAnalyticsScript(
   process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
+  manualPageviews,
 );
 
 export const metadata: Metadata = {
@@ -77,9 +80,13 @@ export default function RootLayout({
       </head>
       <body className={inter.className}>
         {googleAnalyticsScript && (
-          <Script id="google-analytics" strategy="afterInteractive">
-            {googleAnalyticsScript}
-          </Script>
+          <Suspense fallback={null}>
+            <GoogleAnalytics
+              script={googleAnalyticsScript}
+              configuredId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? ""}
+              manualPageviews={manualPageviews}
+            />
+          </Suspense>
         )}
         <a
           href="#main-content"

--- a/apps/web/src/components/google-analytics.tsx
+++ b/apps/web/src/components/google-analytics.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import Script from "next/script";
+import { resolveGoogleAnalyticsId } from "@/lib/google-analytics-config.mjs";
+import { createPageviewCoordinator } from "@/lib/google-analytics-pageviews.mjs";
+import type {} from "@/lib/analytics";
+
+/** Own both initial and subsequent pageviews when the rollout flag is enabled. */
+export function GoogleAnalytics({
+  script,
+  configuredId,
+  manualPageviews,
+}: {
+  script: string;
+  configuredId: string;
+  manualPageviews: boolean;
+}) {
+  const pathname = usePathname();
+  const query = useSearchParams().toString();
+  const coordinator = useRef<ReturnType<typeof createPageviewCoordinator> | null>(null);
+
+  useEffect(() => {
+    if (!manualPageviews) return;
+    const measurementId = resolveGoogleAnalyticsId(configuredId, window.location.hostname);
+    if (!measurementId) return;
+
+    if (!coordinator.current) {
+      coordinator.current = createPageviewCoordinator(measurementId, (parameters) => {
+        // The bootstrap configures the destination before inserting this tag.
+        // A delayed bootstrap must not lose the initial visit or send prematurely.
+        if (!window.gtag || !document.getElementById("quickvoice-google-tag")) return false;
+        window.gtag("event", "page_view", parameters);
+        return true;
+      });
+    }
+    const current = coordinator.current;
+    // Read metadata after React's route commit, not at the history mutation.
+    // Cleanup drops a pending callback when a navigation is superseded.
+    const timer = window.setTimeout(() => {
+      if (
+        window.location.pathname !== pathname ||
+        new URLSearchParams(window.location.search).toString() !== query
+      ) return;
+      current.record({
+        url: window.location.href,
+        title: document.title,
+        referrer: document.referrer,
+      });
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [pathname, query, configuredId, manualPageviews]);
+
+  return (
+    <Script
+      id="google-analytics"
+      strategy="afterInteractive"
+      onReady={() => coordinator.current?.flush()}
+    >
+      {script}
+    </Script>
+  );
+}

--- a/apps/web/src/lib/google-analytics-config.mjs
+++ b/apps/web/src/lib/google-analytics-config.mjs
@@ -1,7 +1,16 @@
 export const QUICKVOICE_GA_MEASUREMENT_ID = "G-SZFBG11VRP";
 
-/** The verified default belongs only to QuickVoice's public website. */
-export function createGoogleAnalyticsScript(configuredId = "") {
+/** Only an explicit opt-in may replace GA's automatic pageview measurement. */
+export function manualPageviewsEnabled(value = "") {
+  return value.trim().toLowerCase() === "true";
+}
+
+/**
+ * Omit hostname only for server-side configuration validation.
+ * @param {string} configuredId
+ * @param {string | null} hostname
+ */
+export function resolveGoogleAnalyticsId(configuredId = "", hostname = null) {
   const override = configuredId.trim();
   if (override.toLowerCase() === "off") return null;
 
@@ -11,14 +20,25 @@ export function createGoogleAnalyticsScript(configuredId = "") {
       "NEXT_PUBLIC_GA_MEASUREMENT_ID must be a GA4 G- ID or off.",
     );
   }
+  if (
+    !override && hostname !== null &&
+    !["quickvoice.co", "www.quickvoice.co"].includes(hostname)
+  ) return null;
+  return measurementId;
+}
+
+/** The verified default belongs only to QuickVoice's public website. */
+export function createGoogleAnalyticsScript(configuredId = "", manualPageviews = false) {
+  const measurementId = resolveGoogleAnalyticsId(configuredId);
+  if (!measurementId) return null;
 
   return `(() => {
-    if (${!override} && !["quickvoice.co", "www.quickvoice.co"].includes(window.location.hostname)) return;
+    if (${!configuredId.trim()} && !["quickvoice.co", "www.quickvoice.co"].includes(window.location.hostname)) return;
     if (document.getElementById("quickvoice-google-tag")) return;
     window.dataLayer = window.dataLayer || [];
     window.gtag = window.gtag || function () { window.dataLayer.push(arguments); };
     window.gtag("js", new Date());
-    window.gtag("config", ${JSON.stringify(measurementId)});
+    window.gtag("config", ${JSON.stringify(measurementId)}${manualPageviews ? ", { send_page_view: false }" : ""});
     const tag = document.createElement("script");
     tag.id = "quickvoice-google-tag";
     tag.async = true;

--- a/apps/web/src/lib/google-analytics-pageviews.mjs
+++ b/apps/web/src/lib/google-analytics-pageviews.mjs
@@ -1,0 +1,45 @@
+/**
+ * One coordinator per mounted app layout. Completed visits are queued until the
+ * tag is ready; only consecutive identical URLs are duplicates, so back/forward
+ * visits still count. Snapshots retain their own title and previous-page referrer.
+ *
+ * @param {string} measurementId
+ * @param {(parameters: Record<string, string>) => boolean} send
+ */
+export function createPageviewCoordinator(measurementId, send) {
+  let previousLocation = "";
+  const pending = [];
+
+  function flush() {
+    while (pending.length) {
+      try {
+        if (!send(pending[0])) return;
+      } catch {
+        return;
+      }
+      pending.shift();
+    }
+  }
+
+  /** @param {{ url: string, title: string, referrer?: string }} page */
+  function record({ url, title, referrer = "" }) {
+    const location = new URL(url);
+    if (!["http:", "https:"].includes(location.protocol)) return false;
+    location.hash = "";
+    if (location.href === previousLocation) {
+      flush();
+      return false;
+    }
+    pending.push({
+      send_to: measurementId,
+      page_location: location.href,
+      page_title: title,
+      page_referrer: previousLocation || referrer.split("#")[0],
+    });
+    previousLocation = location.href;
+    flush();
+    return true;
+  }
+
+  return { record, flush };
+}

--- a/apps/web/tests/google-analytics-config.test.mjs
+++ b/apps/web/tests/google-analytics-config.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { runInNewContext } from "node:vm";
-import { createGoogleAnalyticsScript } from "../src/lib/google-analytics-config.mjs";
+import {
+  createGoogleAnalyticsScript,
+  manualPageviewsEnabled,
+  resolveGoogleAnalyticsId,
+} from "../src/lib/google-analytics-config.mjs";
 
 function browser(hostname) {
   const scripts = [];
@@ -60,4 +64,32 @@ test("explicit configuration supports a different property and an off switch", (
     () => createGoogleAnalyticsScript("invalid'ID"),
     /must be a GA4 G- ID or off/,
   );
+});
+
+test("manual pageviews require an explicit opt-in and suppress the automatic initial view only then", () => {
+  for (const setting of [undefined, "", "false", "1", "yes"]) {
+    assert.equal(manualPageviewsEnabled(setting), false);
+    const { context } = browser("quickvoice.co");
+    runInNewContext(createGoogleAnalyticsScript("", manualPageviewsEnabled(setting)), context);
+    assert.equal(context.window.dataLayer[1].length, 2);
+  }
+  const { context } = browser("quickvoice.co");
+  assert.equal(manualPageviewsEnabled(" true "), true);
+  runInNewContext(createGoogleAnalyticsScript("", true), context);
+  assert.equal(context.window.dataLayer[1][2].send_page_view, false);
+  assert.equal(context.window.dataLayer.filter((args) => args[0] === "event").length, 0);
+});
+
+test("the pageview coordinator uses the same destination and host guards as the bootstrap", () => {
+  assert.equal(resolveGoogleAnalyticsId("", "quickvoice.co"), "G-SZFBG11VRP");
+  assert.equal(resolveGoogleAnalyticsId("", "www.quickvoice.co"), "G-SZFBG11VRP");
+  for (const host of ["localhost", "preview.quickvoice.co", "quickvoice.co.example.com"]) {
+    assert.equal(resolveGoogleAnalyticsId("", host), null);
+    const { context, scripts } = browser(host);
+    runInNewContext(createGoogleAnalyticsScript("", true), context);
+    assert.equal(scripts.length, 0);
+  }
+  assert.equal(resolveGoogleAnalyticsId("G-TEST123", "localhost"), "G-TEST123");
+  assert.equal(resolveGoogleAnalyticsId("off", "quickvoice.co"), null);
+  assert.equal(createGoogleAnalyticsScript("off", true), null);
 });

--- a/apps/web/tests/google-analytics-pageviews.test.mjs
+++ b/apps/web/tests/google-analytics-pageviews.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createPageviewCoordinator } from "../src/lib/google-analytics-pageviews.mjs";
+
+test("initial, committed path/query, back and forward visits count once; duplicate and hash changes do not", () => {
+  const events = [];
+  const tracker = createPageviewCoordinator("G-TEST123", (event) => { events.push(event); return true; });
+  const home = { url: "https://quickvoice.co/", title: "Home", referrer: "https://example.com/search#result" };
+  const blog = { url: "https://quickvoice.co/blog", title: "Blog" };
+  const filtered = { url: "https://quickvoice.co/blog?category=scheduling", title: "Blog" };
+
+  assert.equal(tracker.record(home), true);
+  assert.equal(tracker.record(home), false); // Strict Mode effect replay.
+  assert.equal(tracker.record({ ...home, url: home.url + "#main-content" }), false);
+  tracker.record(blog);
+  tracker.record(filtered);
+  tracker.record(blog); // Back.
+  tracker.record(filtered); // Forward.
+  tracker.record(filtered); // Unchanged replace/refresh.
+  tracker.flush();
+
+  assert.deepEqual(events.map((event) => event.page_location), [home.url, blog.url, filtered.url, blog.url, filtered.url]);
+  assert.deepEqual(events.map((event) => event.page_referrer), ["https://example.com/search", home.url, blog.url, filtered.url, blog.url]);
+  assert.deepEqual(events.map((event) => event.page_title), ["Home", "Blog", "Blog", "Blog", "Blog"]);
+  assert.ok(events.every((event) => event.send_to === "G-TEST123"));
+});
+
+test("late tag readiness preserves each completed visit's title and referrer without duplicate flushing", () => {
+  let ready = false;
+  const events = [];
+  const tracker = createPageviewCoordinator("G-TEST123", (event) => {
+    if (!ready) return false;
+    events.push(event);
+    return true;
+  });
+  tracker.record({ url: "https://quickvoice.co/", title: "Initial title" });
+  tracker.record({ url: "https://quickvoice.co/blog?sort=new", title: "Updated title" });
+  assert.equal(events.length, 0);
+  ready = true;
+  tracker.flush();
+  tracker.flush();
+  tracker.record({ url: "https://quickvoice.co/blog?sort=new#archive", title: "Updated title" });
+  assert.equal(events.length, 2);
+  assert.equal(events[0].page_title, "Initial title");
+  assert.equal(events[1].page_title, "Updated title");
+  assert.equal(events[1].page_referrer, "https://quickvoice.co/");
+});
+
+test("an unavailable sender does not crash navigation or discard an unsent view", () => {
+  let unavailable = true;
+  const events = [];
+  const tracker = createPageviewCoordinator("G-TEST123", (event) => {
+    if (unavailable) throw new Error("Tag not ready");
+    events.push(event);
+    return true;
+  });
+  assert.doesNotThrow(() => tracker.record({ url: "https://quickvoice.co/blog", title: "Blog" }));
+  unavailable = false;
+  tracker.flush();
+  tracker.flush();
+  assert.equal(events.length, 1);
+});

--- a/docs/marketing/seo/pageview-rollout.md
+++ b/docs/marketing/seo/pageview-rollout.md
@@ -1,0 +1,16 @@
+# Explicit pageview rollout
+
+The web app can own both the initial `page_view` and subsequent completed App Router visits. This mode is staged behind `NEXT_PUBLIC_GA_MANUAL_PAGEVIEWS=true`; blank, `false`, and other values keep it disabled. Deploying the code with the default setting preserves the existing automatic initial pageview and adds no manual pageviews.
+
+As checked on 2026-09-06, the production stream's enhanced browser-history measurement remains enabled and the connected Analytics account lacks edit access. **Do not enable manual mode until an authorized GA editor disables “Page changes based on browser history events” for the destination stream.** `send_page_view: false` suppresses the tag's initial automatic view, but does not suppress Enhanced Measurement's independent history events. [Google's pageview documentation](https://developers.google.com/analytics/devguides/collection/ga4/views) explains both controls.
+
+Roll out in this order:
+
+1. Keep the build flag absent or `false` while deploying the staged code.
+2. Using GA edit access, disable the stream's browser-history pageviews and verify the saved setting. Keep unrelated enhanced events unchanged. For QuickVoice, confirm the stream uses `G-SZFBG11VRP`.
+3. Set `NEXT_PUBLIC_GA_MANUAL_PAGEVIEWS=true` in the marketing app's **build environment**, then rebuild and deploy. An ID override requires the same GA-side check for that destination.
+4. Verify one initial view and one view per completed path/query change, including back/forward. Confirm updated title and referrer, and no view for unchanged URLs or fragments. Check actual collection and GA receipt separately. [Google's SPA verification guidance](https://developers.google.com/analytics/devguides/collection/ga4/single-page-applications) describes checking location and referrer across views.
+
+The coordinator uses the existing measurement-ID rules: the default runs only on `quickvoice.co` and `www.quickvoice.co`; an explicit `G-` ID works on any host; `off` disables tracking. Manual mode configures `send_page_view: false` and queues explicit events until the bootstrap is ready. It reads the title after the committed route updates and uses the preceding tracked URL as the next referrer. Query strings participate in view identity; fragments do not. Keep personal data out of page URLs, as with GA's automatic page-location collection.
+
+For rollback, rebuild with the manual flag `false` first, verify the new build, then restore GA's history setting if desired. This order avoids overlapping manual and automatic history collection. There may be a measurement gap during either transition; record the change times. Do not claim rollout complete while GA edit access or production enablement remains pending.


### PR DESCRIPTION
## Summary

The live Google tag sends an initial page view but does not consistently report client-side navigation. Add one client coordinator for initial, path/query and back/forward page views, with correct titles/referrers and duplicate protection.

Explicit page views are behind NEXT_PUBLIC_GA_MANUAL_PAGEVIEWS=true. The default preserves current behavior until the production GA stream's automatic history page views are disabled, avoiding duplicate counting during staged rollout. The existing production-host guard, measurement-ID override, and off switch remain supported.

## Verification

- 32 web tests, lint, types, production build, campaign claims audit across71files, and diff check passed.
- Offline production browser verified initial/path/query/hash/unchanged/back/forward counts of1,2,3,4,4,4,5,6; correct titles/referrers; one tag/config; and no default Google traffic on localhost.
- Default-disabled behavior passed unit/source checks. An extra development-browser check did not hydrate in its bounded window, so no browser result is claimed for that extra check.
- Required full CI runs before merge; no dependency changes, database migrations, or visible UI changes.
- Environment example and pageview rollout guide document activation, verification and rollback. task doctor is unavailable on this host because go-task/Corepack are missing.

## Release notes

Keep the flag disabled until an authorized GA editor disables automatic history page views. Then enable it at production build time, redeploy, and verify both network requests and GA reporting. Enabling this flag alone before the GA setting change is not a completed rollout. Requested as stage1 of the approved remaining SEO plan; commit/PR/merge are authorized.
