### PR TITLE
Add a verified manual deployment route for the public website

### DIFF
--- a/.github/WEB_DEPLOYMENT.md
+++ b/.github/WEB_DEPLOYMENT.md
@@ -1,0 +1,31 @@
+# Marketing website deployment
+
+The production website is the existing Coolify application
+`76d9ooqtvm1hl9tbzmza3few`, serving `https://quickvoice.co` from this
+repository's `main` branch. Its environment and build configuration remain in
+Coolify.
+
+When a merged website release has not appeared, run **Deploy QuickVoice
+Website** in GitHub Actions on `main`:
+
+```sh
+gh workflow run deploy-web.yml --ref main
+```
+
+The manual workflow uses the existing `COOLIFY_API_URL` repository variable
+(`https://webhook.quickintell.com/api/v1`) and `COOLIFY_API_TOKEN` repository
+secret. It requires completed quality and dependency-security checks for the
+exact current main commit. It does not deploy the backend, console, or docs.
+
+The helper validates the application identity before requesting deployment,
+avoids adding another deployment while a different revision is active, and
+checks the deployment UUID, final commit, and application health. Credentials
+and raw API responses are not written to logs.
+
+If a deployment request times out or returns an error, the helper reconciles
+the application queue once using GET requests. It does not repeat the POST.
+Inspect Coolify before retrying an ambiguous or unfinished request.
+
+A successful workflow confirms the deployment and application health. Verify
+the public homepage and changed routes afterward; GitHub merge status alone
+does not establish that a release is live.

--- a/.github/scripts/deploy-web.mjs
+++ b/.github/scripts/deploy-web.mjs
@@ -1,0 +1,206 @@
+import { appendFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export const WEB_APP_UUID = "76d9ooqtvm1hl9tbzmza3few";
+const API_URL = "https://webhook.quickintell.com/api/v1";
+const activeStatuses = new Set(["queued", "in_progress", "building"]);
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Deploy only the established marketing app; never print raw API responses. */
+export async function deployWeb({
+  apiUrl,
+  token,
+  expectedCommit,
+  fetchImpl = fetch,
+  sleep = delay,
+  log = console.log,
+  pollAttempts = 120,
+  pollIntervalMs = 10_000,
+}) {
+  if (apiUrl?.replace(/\/$/, "") !== API_URL || !token) {
+    throw new Error("Missing credential or unexpected Coolify API URL.");
+  }
+  if (!/^[a-f0-9]{40}$/.test(expectedCommit ?? "")) {
+    throw new Error("A full expected main commit is required.");
+  }
+
+  async function request(path, method = "GET") {
+    let response;
+    try {
+      response = await fetchImpl(`${API_URL}${path}`, {
+        method,
+        redirect: "error",
+        signal: AbortSignal.timeout(30_000),
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+          "User-Agent": "Mozilla/5.0 QuickVoice-Web-Deploy",
+        },
+      });
+    } catch {
+      throw new Error(`Coolify ${method} request did not receive a response.`);
+    }
+    if (!response.ok) {
+      throw new Error(`Coolify ${method} returned HTTP ${response.status}.`);
+    }
+    try {
+      return await response.json();
+    } catch {
+      throw new Error(`Coolify ${method} returned invalid JSON.`);
+    }
+  }
+
+  const appPath = `/applications/${WEB_APP_UUID}`;
+  const app = await request(appPath);
+  const repo = app.git_repository
+    ?.replace(/^https:\/\/github\.com\//, "")
+    .replace(/\.git$/, "");
+  const domains = String(app.fqdn ?? "")
+    .split(",")
+    .map((domain) => domain.trim().replace(/\/$/, ""));
+  if (
+    app.uuid !== WEB_APP_UUID ||
+    repo !== "allgpt-co/QuickVoice" ||
+    app.git_branch !== "main" ||
+    app.git_commit_sha !== "HEAD" ||
+    !domains.includes("https://quickvoice.co") ||
+    app.id == null
+  ) {
+    throw new Error(
+      "Marketing application identity or main-branch configuration does not match.",
+    );
+  }
+
+  async function listDeployments() {
+    const response = await request(
+      `/deployments/applications/${WEB_APP_UUID}?take=10`,
+    );
+    const rows = Array.isArray(response) ? response : response.deployments;
+    if (!Array.isArray(rows))
+      throw new Error("Unexpected application deployment list.");
+    return rows;
+  }
+
+  const before = await listDeployments();
+  const active = before.filter((row) => activeStatuses.has(row.status));
+  if (
+    active.length > 1 ||
+    (active.length === 1 && active[0].commit !== expectedCommit)
+  ) {
+    throw new Error(
+      "Another marketing deployment is active; no additional deployment was requested.",
+    );
+  }
+  let deploymentUuid = active[0]?.deployment_uuid;
+  if (!deploymentUuid) {
+    let queued;
+    try {
+      queued = await request(
+        `/deploy?uuid=${WEB_APP_UUID}&force=false`,
+        "POST",
+      );
+    } catch {
+      // A timeout/502 can follow an accepted request. Reconcile once, never POST again.
+      const known = new Set(before.map((row) => row.deployment_uuid));
+      const candidates = (await listDeployments()).filter(
+        (row) =>
+          !known.has(row.deployment_uuid) && row.commit === expectedCommit,
+      );
+      if (candidates.length !== 1) {
+        throw new Error(
+          "Deployment acknowledgment was unavailable; inspect Coolify before retrying. POST was not repeated.",
+        );
+      }
+      deploymentUuid = candidates[0].deployment_uuid;
+    }
+    if (queued) {
+      const entries = queued.deployments;
+      if (
+        !Array.isArray(entries) ||
+        entries.length !== 1 ||
+        entries[0].resource_uuid !== WEB_APP_UUID
+      ) {
+        throw new Error(
+          "Unexpected deployment acknowledgment; inspect Coolify before retrying.",
+        );
+      }
+      deploymentUuid = entries[0].deployment_uuid;
+    }
+  }
+  if (!/^[a-zA-Z0-9-]+$/.test(deploymentUuid ?? "")) {
+    throw new Error(
+      "Missing or invalid deployment identifier; inspect Coolify before retrying.",
+    );
+  }
+
+  log(`Watching marketing deployment ${deploymentUuid} for ${expectedCommit}.`);
+  for (let attempt = 0; attempt < pollAttempts; attempt++) {
+    let deployment;
+    try {
+      deployment = await request(`/deployments/${deploymentUuid}`);
+    } catch (error) {
+      if (attempt + 1 === pollAttempts) throw error;
+      log(
+        "Deployment status temporarily unavailable; retrying a read-only check.",
+      );
+      await sleep(pollIntervalMs);
+      continue;
+    }
+    if (
+      deployment.deployment_uuid !== deploymentUuid ||
+      String(deployment.application_id) !== String(app.id)
+    ) {
+      throw new Error(
+        "Deployment does not belong to the expected marketing application.",
+      );
+    }
+    if (
+      ["failed", "cancelled", "canceled", "cancelled-by-user"].includes(
+        deployment.status,
+      )
+    ) {
+      throw new Error(
+        `Marketing deployment ${deploymentUuid} did not finish successfully.`,
+      );
+    }
+    if (deployment.status === "finished") {
+      if (deployment.commit !== expectedCommit)
+        throw new Error(
+          "Deployed commit does not match the expected main commit.",
+        );
+      const current = await request(appPath);
+      if (current.status !== "running:healthy")
+        throw new Error(
+          "Deployment finished but the marketing application is not healthy.",
+        );
+      return { deploymentUuid, commit: deployment.commit, status: "finished" };
+    }
+    if (!activeStatuses.has(deployment.status))
+      throw new Error("Unexpected deployment status.");
+    log(`Marketing deployment ${deploymentUuid}: ${deployment.status}.`);
+    await sleep(pollIntervalMs);
+  }
+  throw new Error(
+    `Deployment ${deploymentUuid} is still pending. Inspect Coolify; no deployment was cancelled or repeated.`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    const result = await deployWeb({
+      apiUrl: process.env.COOLIFY_API_URL,
+      token: process.env.COOLIFY_API_TOKEN,
+      expectedCommit: process.env.GITHUB_SHA,
+    });
+    const summary = `Marketing deployment finished: ${result.deploymentUuid}\nCommit: ${result.commit}\nApplication: running:healthy\nPublic URL: https://quickvoice.co\n`;
+    console.log(summary);
+    if (process.env.GITHUB_STEP_SUMMARY)
+      await appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,50 @@
+name: Deploy QuickVoice Website
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: read
+
+concurrency:
+  group: quickvoice-web-production
+  cancel-in-progress: false
+
+jobs:
+  deploy-web:
+    if: github.repository == 'allgpt-co/QuickVoice' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Confirm this run still targets current main
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_main=$(git ls-remote origin refs/heads/main | cut -f1)
+          test "$current_main" = "$GITHUB_SHA"
+      - name: Require successful quality and security checks for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/allgpt-co/QuickVoice/commits/$GITHUB_SHA/check-runs?per_page=100" \
+            --jq '.check_runs' > "$RUNNER_TEMP/web-release-checks.json"
+          jq -e '
+            . as $checks |
+            ["Quality Summary", "Dependency Security Audit"] |
+            all(. as $name |
+              [$checks[] | select(.name == $name)] |
+              sort_by(.started_at) | last |
+              .status == "completed" and .conclusion == "success")
+          ' "$RUNNER_TEMP/web-release-checks.json"
+      - name: Deploy and verify the marketing application
+        env:
+          COOLIFY_API_URL: ${{ vars.COOLIFY_API_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+        run: node .github/scripts/deploy-web.mjs

--- a/tests/web-deployment.test.mjs
+++ b/tests/web-deployment.test.mjs
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { deployWeb, WEB_APP_UUID } from "../.github/scripts/deploy-web.mjs";
+
+const apiUrl = "https://webhook.quickintell.com/api/v1";
+const token = "test-only-coolify-token";
+const expectedCommit = "a".repeat(40);
+const oldCommit = "b".repeat(40);
+const deploymentUuid = "web-deployment-123";
+const applicationPath = `/api/v1/applications/${WEB_APP_UUID}`;
+const listPath = `/api/v1/deployments/applications/${WEB_APP_UUID}`;
+const deployPath = "/api/v1/deploy";
+const statusPath = `/api/v1/deployments/${deploymentUuid}`;
+
+function application(overrides = {}) {
+  return {
+    id: 47,
+    uuid: WEB_APP_UUID,
+    git_repository: "allgpt-co/QuickVoice",
+    git_branch: "main",
+    git_commit_sha: "HEAD",
+    fqdn: "https://quickvoice.co,https://www.quickvoice.co",
+    status: "running:healthy",
+    ...overrides,
+  };
+}
+
+function deployment(overrides = {}) {
+  return {
+    deployment_uuid: deploymentUuid,
+    application_id: 47,
+    commit: expectedCommit,
+    status: "finished",
+    ...overrides,
+  };
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fixture(handler = () => undefined) {
+  const calls = [];
+  const logs = [];
+  const sleeps = [];
+  const fetchImpl = async (input, init = {}) => {
+    const url = new URL(
+      typeof input === "string" || input instanceof URL ? input : input.url,
+    );
+    const method = (
+      init.method ?? (input instanceof Request ? input.method : "GET")
+    ).toUpperCase();
+    const call = { url, method, init };
+    calls.push(call);
+    const customResponse = await handler(call, calls);
+    if (customResponse !== undefined) return customResponse;
+    if (method === "GET" && url.pathname === applicationPath)
+      return json(application());
+    if (method === "GET" && url.pathname === listPath) return json([]);
+    if (method === "POST" && url.pathname === deployPath) {
+      return json({
+        deployments: [
+          { resource_uuid: WEB_APP_UUID, deployment_uuid: deploymentUuid },
+        ],
+      });
+    }
+    if (method === "GET" && url.pathname === statusPath)
+      return json(deployment());
+    throw new Error(`Unexpected mock request: ${method} ${url.pathname}`);
+  };
+  return {
+    calls,
+    logs,
+    sleeps,
+    run: (overrides = {}) =>
+      deployWeb({
+        apiUrl,
+        token,
+        expectedCommit,
+        fetchImpl,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+        log: (...values) => {
+          logs.push(values.join(" "));
+        },
+        pollAttempts: 3,
+        pollIntervalMs: 1,
+        ...overrides,
+      }),
+  };
+}
+
+function posts(context) {
+  return context.calls.filter((call) => call.method === "POST");
+}
+
+test("web deployment validates the target, queues once, and verifies the finished revision and health", async () => {
+  let polls = 0;
+  const context = fixture(({ url }) => {
+    if (url.pathname === statusPath) {
+      polls += 1;
+      return json(
+        deployment({ status: polls === 1 ? "in_progress" : "finished" }),
+      );
+    }
+  });
+
+  assert.deepEqual(await context.run(), {
+    deploymentUuid,
+    commit: expectedCommit,
+    status: "finished",
+  });
+  assert.equal(posts(context).length, 1);
+  assert.equal(posts(context)[0].url.searchParams.get("uuid"), WEB_APP_UUID);
+  assert.equal(posts(context)[0].url.searchParams.get("force"), "false");
+  assert.equal(
+    context.calls.filter(({ url }) => url.pathname === applicationPath).length,
+    2,
+  );
+  assert.equal(polls, 2);
+  assert.deepEqual(context.sleeps, [1]);
+  assert.ok(
+    context.calls.every(
+      ({ url, init }) =>
+        url.origin === "https://webhook.quickintell.com" &&
+        new Headers(init.headers).get("Authorization") === `Bearer ${token}`,
+    ),
+  );
+  assert.ok(!context.logs.join("\n").includes(token));
+});
+
+test("invalid API origin, revision, or missing credential fails before any request", async (t) => {
+  for (const overrides of [
+    { apiUrl: "https://example.com/api/v1" },
+    { apiUrl: "https://webhook.quickintell.com.example.com/api/v1" },
+    { expectedCommit: "main" },
+    { expectedCommit: "a".repeat(39) },
+    { token: "" },
+  ]) {
+    await t.test(JSON.stringify(overrides), async () => {
+      const context = fixture();
+      await assert.rejects(context.run(overrides));
+      assert.equal(context.calls.length, 0);
+    });
+  }
+});
+
+test("a different application, repository, branch, pinned revision, or misleading domain cannot be deployed", async (t) => {
+  for (const overrides of [
+    { uuid: "another-application" },
+    { git_repository: "another-owner/QuickVoice" },
+    { git_branch: "feature-branch" },
+    { git_commit_sha: oldCommit },
+    { fqdn: "https://quickvoice.co.example.com" },
+  ]) {
+    await t.test(JSON.stringify(overrides), async () => {
+      const context = fixture(({ url }) =>
+        url.pathname === applicationPath
+          ? json(application(overrides))
+          : undefined,
+      );
+      await assert.rejects(context.run());
+      assert.equal(posts(context).length, 0);
+    });
+  }
+});
+
+test("authentication failure aborts before deployment and does not echo response bodies or credentials", async () => {
+  const privateBody = `private-response ${token}`;
+  const context = fixture(() => new Response(privateBody, { status: 401 }));
+  await assert.rejects(context.run(), (error) => {
+    assert.ok(!error.message.includes(privateBody));
+    assert.ok(!error.message.includes(token));
+    return true;
+  });
+  assert.equal(posts(context).length, 0);
+  assert.ok(!context.logs.join("\n").includes(privateBody));
+  assert.ok(!context.logs.join("\n").includes(token));
+});
+
+test("an active deployment of another revision blocks a second queue request", async (t) => {
+  for (const status of ["queued", "in_progress", "building"]) {
+    await t.test(status, async () => {
+      const context = fixture(({ url }) =>
+        url.pathname === listPath
+          ? json({ deployments: [deployment({ status, commit: oldCommit })] })
+          : undefined,
+      );
+      await assert.rejects(context.run());
+      assert.equal(posts(context).length, 0);
+    });
+  }
+});
+
+test("an existing active deployment of the expected revision is monitored without another POST", async () => {
+  const context = fixture(({ url }) =>
+    url.pathname === listPath
+      ? json({ deployments: [deployment({ status: "in_progress" })] })
+      : undefined,
+  );
+  assert.deepEqual(await context.run(), {
+    deploymentUuid,
+    commit: expectedCommit,
+    status: "finished",
+  });
+  assert.equal(posts(context).length, 0);
+});
+
+test("an ambiguous POST is reconciled to exactly one new deployment of the expected revision", async () => {
+  let lists = 0;
+  const context = fixture(({ url, method }) => {
+    if (url.pathname === listPath) {
+      lists += 1;
+      return json(lists === 1 ? [] : [deployment({ status: "queued" })]);
+    }
+    if (method === "POST") throw new Error("upstream connection closed");
+  });
+  assert.deepEqual(await context.run(), {
+    deploymentUuid,
+    commit: expectedCommit,
+    status: "finished",
+  });
+  assert.equal(posts(context).length, 1);
+  assert.equal(lists, 2);
+});
+
+test("an ambiguous POST is never retried when a unique matching new deployment cannot be established", async (t) => {
+  for (const records of [
+    [],
+    [deployment({ commit: oldCommit })],
+    [deployment(), deployment({ deployment_uuid: "another-new-deployment" })],
+  ]) {
+    await t.test(
+      `${records.length} candidates: ${records.map(({ commit }) => commit).join(",")}`,
+      async () => {
+        let lists = 0;
+        const privateBody = `gateway debug: ${token}`;
+        const context = fixture(({ url, method }) => {
+          if (url.pathname === listPath) {
+            lists += 1;
+            return json(lists === 1 ? [] : records);
+          }
+          if (method === "POST")
+            return new Response(privateBody, { status: 502 });
+        });
+        await assert.rejects(context.run(), (error) => {
+          assert.ok(!error.message.includes(privateBody));
+          assert.ok(!error.message.includes(token));
+          return true;
+        });
+        assert.equal(posts(context).length, 1);
+        assert.equal(lists, 2);
+        assert.ok(!context.logs.join("\n").includes(token));
+      },
+    );
+  }
+});
+
+test("an old matching deployment cannot be mistaken for acknowledgement of an ambiguous POST", async () => {
+  const context = fixture(({ url, method }) => {
+    if (url.pathname === listPath) return json([deployment()]);
+    if (method === "POST") throw new Error("connection lost");
+  });
+  await assert.rejects(context.run());
+  assert.equal(posts(context).length, 1);
+});
+
+test("polling rejects foreign application or deployment identifiers", async (t) => {
+  for (const overrides of [
+    { application_id: 48 },
+    { deployment_uuid: "foreign-deployment" },
+  ]) {
+    await t.test(JSON.stringify(overrides), async () => {
+      const context = fixture(({ url }) =>
+        url.pathname === statusPath ? json(deployment(overrides)) : undefined,
+      );
+      await assert.rejects(context.run());
+      assert.equal(posts(context).length, 1);
+    });
+  }
+});
+
+test("failed, cancelled, wrong-revision, and unhealthy deployments never report success", async (t) => {
+  for (const overrides of [
+    { status: "failed" },
+    { status: "cancelled" },
+    { status: "cancelled-by-user" },
+    { commit: oldCommit },
+  ]) {
+    await t.test(JSON.stringify(overrides), async () => {
+      const context = fixture(({ url }) =>
+        url.pathname === statusPath ? json(deployment(overrides)) : undefined,
+      );
+      await assert.rejects(context.run());
+      assert.equal(posts(context).length, 1);
+    });
+  }
+  await t.test("unhealthy application after finished deployment", async () => {
+    let applicationReads = 0;
+    const context = fixture(({ url }) => {
+      if (url.pathname === applicationPath) {
+        applicationReads += 1;
+        return json(
+          application({
+            status:
+              applicationReads === 1 ? "running:healthy" : "running:unhealthy",
+          }),
+        );
+      }
+    });
+    await assert.rejects(context.run());
+    assert.equal(applicationReads, 2);
+  });
+});
+
+test("an unfinished deployment exhausts bounded polling without queueing another deployment", async () => {
+  const context = fixture(({ url }) =>
+    url.pathname === statusPath
+      ? json(deployment({ status: "in_progress" }))
+      : undefined,
+  );
+  await assert.rejects(context.run());
+  assert.equal(
+    context.calls.filter(({ url }) => url.pathname === statusPath).length,
+    3,
+  );
+  assert.equal(posts(context).length, 1);
+});


### PR DESCRIPTION
A merged marketing release can remain on the previous production version when the Coolify webhook is unavailable. Add a manual GitHub Actions deployment route using the existing repository credential, so the marketing application can be deployed and verified without moving secrets into a local workspace.

The workflow runs only on current `main` in this repository after its quality and dependency-security checks succeed. It validates the fixed website application, repository, branch and domain; sends one deployment request; reconciles ambiguous acknowledgments with read-only requests; and verifies the deployment UUID, exact commit and healthy application status. It preserves all Coolify environment/build settings and targets only the marketing application.

Validation: actionlint 1.7.12, Node syntax checking, formatting and all 75 root tests passed, including 35 deployment tests/subtests for target validation, error redaction, duplicate prevention, failed deployments and revision mismatches. No website application code changed. Live website checks will follow the first successful deployment.

Release result: merged as `4b14988eb59e56046db2a706671af40719cb7307` after all 11 PR checks passed; CI and the dependency audit also passed on that exact main commit. [First deployment run](https://github.com/allgpt-co/QuickVoice/actions/runs/34099862163) passed the main/quality checks but stopped at the first Coolify GET with HTTP 401. No deployment POST was sent. The API outage has recovered, but the existing repository credential is rejected. Update `COOLIFY_API_TOKEN` in GitHub Actions secrets before rerunning this manual workflow. As of September 7 at 08:20 UTC, the homepage still returns HTTP 200 with the previous design.
